### PR TITLE
[Relates #7] Create importer orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ pip install -e git+https://github.com/geosolutions-it/geonode-importer.git@maste
 Add to settings:
 
 ```
+CELERY_TASK_QUEUES += (
+    Queue('importer.import_derivator', GEONODE_EXCHANGE, routing_key='importer.import_derivator', priority=0),
+    Queue('importer.import_resource', GEONODE_EXCHANGE, routing_key='importer.import_resource', priority=0),
+    Queue('importer.publish_resource', GEONODE_EXCHANGE, routing_key='importer.publish_resource', priority=0),
+    Queue('importer.create_gn_resource', GEONODE_EXCHANGE, routing_key='importer.create_gn_resource', priority=0),
+)
+
 INSTALLED_APPS += ('importer', 'dynamic_models',)
 
 DYNAMIC_MODELS = {
    "USE_APP_LABEL": "importer"
 }
+
 ```
 
 Run migrations:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add to settings:
 
 ```
 CELERY_TASK_QUEUES += (
-    Queue('importer.import_derivator', GEONODE_EXCHANGE, routing_key='importer.import_derivator', priority=0),
+    Queue('importer.import_orchestrator', GEONODE_EXCHANGE, routing_key='importer.import_orchestrator', priority=0),
     Queue('importer.import_resource', GEONODE_EXCHANGE, routing_key='importer.import_resource', priority=0),
     Queue('importer.publish_resource', GEONODE_EXCHANGE, routing_key='importer.publish_resource', priority=0),
     Queue('importer.create_gn_resource', GEONODE_EXCHANGE, routing_key='importer.create_gn_resource', priority=0),

--- a/importer/admin.py
+++ b/importer/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/importer/api/tests.py
+++ b/importer/api/tests.py
@@ -61,7 +61,7 @@ class TestImporterViewSet(GeoNodeBaseTestSupport):
         self.assertTrue(500, response.status_code)
         self.assertEqual(expected, response.json())
 
-    @patch('importer.api.views.start_dataset_import')
+    @patch('importer.api.views.import_derivator')
     def test_gpkg_task_is_called(self, patch_upload):
         patch_upload.apply_async.side_effect = MagicMock()
 

--- a/importer/api/tests.py
+++ b/importer/api/tests.py
@@ -61,7 +61,7 @@ class TestImporterViewSet(GeoNodeBaseTestSupport):
         self.assertTrue(500, response.status_code)
         self.assertEqual(expected, response.json())
 
-    @patch('importer.api.views.run_dataset_import')
+    @patch('importer.api.views.start_dataset_import')
     def test_gpkg_task_is_called(self, patch_upload):
         patch_upload.apply_async.side_effect = MagicMock()
 

--- a/importer/api/tests.py
+++ b/importer/api/tests.py
@@ -61,7 +61,7 @@ class TestImporterViewSet(GeoNodeBaseTestSupport):
         self.assertTrue(500, response.status_code)
         self.assertEqual(expected, response.json())
 
-    @patch('importer.api.views.import_derivator')
+    @patch('importer.api.views.import_orchestrator')
     def test_gpkg_task_is_called(self, patch_upload):
         patch_upload.apply_async.side_effect = MagicMock()
 

--- a/importer/api/views.py
+++ b/importer/api/views.py
@@ -30,7 +30,7 @@ from geonode.upload.api.views import UploadViewSet
 from geonode.upload.models import Upload
 from importer.api.exception import ImportException
 from importer.api.serializer import ImporterSerializer
-from importer.views import run_dataset_import
+from importer.views import start_dataset_import
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework.authentication import (BasicAuthentication,
                                            SessionAuthentication)
@@ -78,8 +78,8 @@ class ImporterViewSet(DynamicModelViewSet):
             # get filepath
             files = storage_manager.get_retrieved_paths()
             try:
-                run_dataset_import.apply_async(
-                    (files, data.data.get("store_spatial_files"))
+                start_dataset_import.apply_async(
+                    (files, data.data.get("store_spatial_files"), request.user.username)
                 )
                 return Response(status=201)
             except Exception as e:

--- a/importer/api/views.py
+++ b/importer/api/views.py
@@ -30,7 +30,7 @@ from geonode.upload.api.views import UploadViewSet
 from geonode.upload.models import Upload
 from importer.api.exception import ImportException
 from importer.api.serializer import ImporterSerializer
-from importer.views import start_dataset_import
+from importer.views import import_derivator
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework.authentication import (BasicAuthentication,
                                            SessionAuthentication)
@@ -78,7 +78,7 @@ class ImporterViewSet(DynamicModelViewSet):
             # get filepath
             files = storage_manager.get_retrieved_paths()
             try:
-                start_dataset_import.apply_async(
+                import_derivator.apply_async(
                     (files, data.data.get("store_spatial_files"), request.user.username)
                 )
                 return Response(status=201)

--- a/importer/api/views.py
+++ b/importer/api/views.py
@@ -30,7 +30,7 @@ from geonode.upload.api.views import UploadViewSet
 from geonode.upload.models import Upload
 from importer.api.exception import ImportException
 from importer.api.serializer import ImporterSerializer
-from importer.views import import_derivator
+from importer.views import import_orchestrator
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework.authentication import (BasicAuthentication,
                                            SessionAuthentication)
@@ -78,7 +78,7 @@ class ImporterViewSet(DynamicModelViewSet):
             # get filepath
             files = storage_manager.get_retrieved_paths()
             try:
-                import_derivator.apply_async(
+                import_orchestrator.apply_async(
                     (files, data.data.get("store_spatial_files"), request.user.username)
                 )
                 return Response(status=201)

--- a/importer/apps.py
+++ b/importer/apps.py
@@ -15,16 +15,17 @@ def run_setup_hooks(*args, **kwargs):
     from django.conf.urls import include, url
     from geonode.urls import urlpatterns
     from geonode.settings import CELERY_TASK_QUEUES, GEONODE_EXCHANGE, Queue
-   
+
     url_already_injected = any(
         [
-            'importer.urls' in x.urlconf_name.__name__
+            "importer.urls" in x.urlconf_name.__name__
             for x in urlpatterns
-            if hasattr(x, 'urlconf_name') and not isinstance(x.urlconf_name, list)
+            if hasattr(x, "urlconf_name") and not isinstance(x.urlconf_name, list)
         ]
     )
 
     if not url_already_injected:
         urlpatterns.insert(
-            0, url(r"^api/v2/", include("importer.api.urls")),
+            0,
+            url(r"^api/v2/", include("importer.api.urls")),
         )

--- a/importer/celery_app.py
+++ b/importer/celery_app.py
@@ -1,3 +1,3 @@
 from celery import Celery
 
-app = Celery('importer')
+app = Celery("importer")

--- a/importer/celery_app.py
+++ b/importer/celery_app.py
@@ -1,0 +1,3 @@
+from celery import Celery
+
+app = Celery('importer')

--- a/importer/datastore.py
+++ b/importer/datastore.py
@@ -7,7 +7,7 @@ class DataStoreManager:
         self.handler = SUPPORTED_TYPES.get(resource_type)
 
     def is_valid(self):
-        '''
+        """
         Perform basic validation steps
-        '''
+        """
         return self.handler.is_valid(self.files)

--- a/importer/datastore.py
+++ b/importer/datastore.py
@@ -1,0 +1,13 @@
+from importer.orchestrator import SUPPORTED_TYPES
+
+
+class DataStoreManager:
+    def __init__(self, files: list, resource_type: str) -> None:
+        self.files = files
+        self.handler = SUPPORTED_TYPES.get(resource_type)
+
+    def is_valid(self):
+        '''
+        Perform basic validation steps
+        '''
+        return self.handler.is_valid(self.files)

--- a/importer/handlers.py
+++ b/importer/handlers.py
@@ -1,16 +1,26 @@
 from abc import ABC
+import os
 
 class AbstractHandler(ABC):
     TASKS_LIST = []
 
     def step_list(self):
         return self.TASKS_LIST
+    
+    def is_valid(self):
+        '''
+        Define basic validation steps
+        '''
+        return NotImplementedError
 
 
-class GPKGStepHandler(AbstractHandler):
+class GPKGFileHandler(AbstractHandler):
     TASKS_LIST = (
         "start_import",
         "importer.import_resource",
         "importer.publish_resource",
-        "importer.create_resource",
+        "importer.create_gn_resource",
     )
+
+    def is_valid(self, files):
+        return all([os.path.exists(x) for x in files])

--- a/importer/handlers.py
+++ b/importer/handlers.py
@@ -1,16 +1,17 @@
 from abc import ABC
 import os
 
+
 class AbstractHandler(ABC):
     TASKS_LIST = []
 
     def step_list(self):
         return self.TASKS_LIST
-    
+
     def is_valid(self):
-        '''
+        """
         Define basic validation steps
-        '''
+        """
         return NotImplementedError
 
 

--- a/importer/handlers.py
+++ b/importer/handlers.py
@@ -1,0 +1,16 @@
+from abc import ABC
+
+class AbstractHandler(ABC):
+    TASKS_LIST = []
+
+    def step_list(self):
+        return self.TASKS_LIST
+
+
+class GPKGStepHandler(AbstractHandler):
+    TASKS_LIST = (
+        "start_import",
+        "importer.import_resource",
+        "importer.publish_resource",
+        "importer.create_resource",
+    )

--- a/importer/models.py
+++ b/importer/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/importer/orchestrator.py
+++ b/importer/orchestrator.py
@@ -19,7 +19,7 @@ class ImportOrchestrator:
         self.enable_legacy_upload_status = enable_legacy_upload_status
 
     @property
-    def get_supported_type_list(self):
+    def supported_type(self):
         '''
         Returns the supported types for the import
         '''
@@ -29,11 +29,20 @@ class ImportOrchestrator:
         '''
         Returns the supported types for the import
         '''
-        return SUPPORTED_TYPES.get(file_type)
+        _type = SUPPORTED_TYPES.get(file_type)
+        if not _type:
+            raise ImportException(detail=f"The requested filetype is not supported: {file_type}")
+        return _type
+
+    def get_execution_object(self, exec_id):
+        req = ExecutionRequest.objects.filter(exec_id=exec_id).first()
+        if req is None:
+            raise ImportException("The selected UUID does not exists")
+        return req
 
     def perform_next_import_step(self, resource_type: str, execution_id: str) -> None:
         # Getting the execution object
-        _exec = self._get_execution_object(str(execution_id))
+        _exec = self.get_execution_object(str(execution_id))
         # retrieve the task list for the resource_type
         tasks = self.get_file_handler(resource_type).TASKS_LIST
         # getting the index
@@ -61,7 +70,6 @@ class ImportOrchestrator:
                 last_updated=datetime.utcnow()
             )            
             raise ImportException(detail=e.args[0])
-        pass
 
 
     def create_execution_request(self, user: get_user_model, func_name: str, step: str, input_params: dict, resource=None) -> str:
@@ -79,9 +87,3 @@ class ImportOrchestrator:
     
     def update_execution_request_status(self, execution_id, **kwargs):
         ExecutionRequest.objects.filter(exec_id=execution_id).update(**kwargs)
-
-    def _get_execution_object(self, exec_id):
-        req = ExecutionRequest.objects.filter(exec_id=exec_id).first()
-        if req is None:
-            raise ImportException("The selected UUID does not exists")
-        return req

--- a/importer/orchestrator.py
+++ b/importer/orchestrator.py
@@ -5,34 +5,38 @@ from geonode.resource.models import ExecutionRequest
 from importer.api.exception import ImportException
 from importer.handlers import GPKGFileHandler
 from importer.celery_app import app
+from geonode.upload.models import Upload
+from geonode.base.enumerations import STATE_RUNNING
 
 logger = logging.getLogger(__name__)
 
 
 SUPPORTED_TYPES = {
     "gpkg": GPKGFileHandler()
-    #"vector": VectorFileHandler
+    # "vector": VectorFileHandler
 }
 
-class ImportOrchestrator:
 
+class ImportOrchestrator:
     def __init__(self, enable_legacy_upload_status=True) -> None:
         self.enable_legacy_upload_status = enable_legacy_upload_status
 
     @property
     def supported_type(self):
-        '''
+        """
         Returns the supported types for the import
-        '''
+        """
         return SUPPORTED_TYPES.keys()
 
     def get_file_handler(self, file_type):
-        '''
+        """
         Returns the supported types for the import
-        '''
+        """
         _type = SUPPORTED_TYPES.get(file_type)
         if not _type:
-            raise ImportException(detail=f"The requested filetype is not supported: {file_type}")
+            raise ImportException(
+                detail=f"The requested filetype is not supported: {file_type}"
+            )
         return _type
 
     def get_execution_object(self, exec_id):
@@ -48,7 +52,7 @@ class ImportOrchestrator:
         tasks = self.get_file_handler(resource_type).TASKS_LIST
         # getting the index
         try:
-            _index = tasks.index(_exec.step)+1
+            _index = tasks.index(_exec.step) + 1
             # finding in the task_list the last step done
             remaining_tasks = tasks[_index:] if not _index >= len(tasks) else []
             if not remaining_tasks:
@@ -56,7 +60,12 @@ class ImportOrchestrator:
             # getting the next step to perform
             next_step = next(iter(remaining_tasks))
             # calling the next step for the resource
-            app.tasks.get(next_step).apply_async((resource_type, str(execution_id),))
+            app.tasks.get(next_step).apply_async(
+                (
+                    resource_type,
+                    str(execution_id),
+                )
+            )
 
         except StopIteration:
             # means that the expected list of steps is completed
@@ -67,23 +76,47 @@ class ImportOrchestrator:
                 execution_id=str(execution_id),
                 status=ExecutionRequest.STATUS_FAILED,
                 finished=datetime.utcnow(),
-                last_updated=datetime.utcnow()
-            )            
+                last_updated=datetime.utcnow(),
+            )
             raise ImportException(detail=e.args[0])
 
-
-    def create_execution_request(self, user: get_user_model, func_name: str, step: str, input_params: dict, resource=None) -> str:
-        '''
+    def create_execution_request(
+        self,
+        user: get_user_model,
+        func_name: str,
+        step: str,
+        input_params: dict,
+        resource=None,
+    ) -> str:
+        """
         Create an execution request for the user. Return the UUID of the request
-        '''
+        """
         execution = ExecutionRequest.objects.create(
             user=user,
             geonode_resource=resource,
             func_name=func_name,
             step=step,
-            input_params=input_params
+            input_params=input_params,
         )
+        if self.enable_legacy_upload_status:
+            Upload.objects.create(
+                state=STATE_RUNNING,
+                metadata={
+                    **{
+                        "func_name": func_name,
+                        "step": step,
+                        "exec_id": str(execution.exec_id),
+                    },
+                    **input_params,
+                },
+            )
         return execution.exec_id
-    
-    def update_execution_request_status(self, execution_id, **kwargs):
-        ExecutionRequest.objects.filter(exec_id=execution_id).update(**kwargs)
+
+    def update_execution_request_status(self, execution_id, status, **kwargs):
+        ExecutionRequest.objects.filter(exec_id=execution_id).update(
+            status=status, **kwargs
+        )
+        if self.enable_legacy_upload_status:
+            Upload.objects.filter(metadata__contains=execution_id).update(
+                state=status, metadata={**kwargs, **{"exec_id": execution_id}}
+            )

--- a/importer/orchestrator.py
+++ b/importer/orchestrator.py
@@ -1,14 +1,19 @@
+from datetime import datetime
+import logging
 from django.contrib.auth import get_user_model
 from geonode.resource.models import ExecutionRequest
 from importer.api.exception import ImportException
-from importer.handlers import GPKGStepHandler
+from importer.handlers import GPKGFileHandler
 
+logger = logging.getLogger(__name__)
+
+
+SUPPORTED_TYPES = {
+    "gpkg": GPKGFileHandler()
+    #"vector": VectorFileHandler
+}
 
 class ImportOrchestrator:
-    SUPPORTED_TYPES = {
-        "gpkg": GPKGStepHandler
-        #"vector": VectorFileHandler
-    }
 
     def __init__(self, enable_legacy_upload_status=True) -> None:
         self.enable_legacy_upload_status = enable_legacy_upload_status
@@ -18,33 +23,48 @@ class ImportOrchestrator:
         '''
         Returns the supported types for the import
         '''
-        return self.SUPPORTED_TYPES.keys()
+        return SUPPORTED_TYPES.keys()
 
     def get_file_handler(self, file_type):
         '''
         Returns the supported types for the import
         '''
-        return self.SUPPORTED_TYPES.get(file_type)
+        return SUPPORTED_TYPES.get(file_type)
 
-    def perform_next_import_step(self, resource_type, execution_id):
+    def perform_next_import_step(self, resource_type: str, execution_id: str) -> None:
         # Getting the execution object
         _exec = self._get_execution_object(str(execution_id))
         # retrieve the task list for the resource_type
         tasks = self.get_file_handler(resource_type).TASKS_LIST
         # getting the index
-        _index = tasks.index(_exec.input_params.get('step'))+1
-        # finding in the task_list the last step done
-        remaining_tasks = tasks[_index:] if not _index > len(tasks) else []
-        # getting the next step to perform
-        next_step = next(iter(remaining_tasks))
-        if not next_step:
+        try:
+            _index = tasks.index(_exec.step)+1
+            # finding in the task_list the last step done
+            remaining_tasks = tasks[_index:] if not _index >= len(tasks) else []
+            if not remaining_tasks:
+                return
+            # getting the next step to perform
+            next_step = next(iter(remaining_tasks))
+            from importer.views import app as celery_app
+            # calling the next step for the resource
+            celery_app.tasks.get(next_step).apply_async((resource_type, str(execution_id),))
+
+        except StopIteration:
+            # means that the expected list of steps is completed
+            logger.info("The whole list of tasks has been processed")
             return
-        from importer.views import app as celery_app
-        print(celery_app)
+        except Exception as e:
+            self.update_execution_request_status(
+                execution_id=execution_id.exec_id,
+                status=ExecutionRequest.STATUS_FAILED,
+                finished=True,
+                last_updated=datetime.utcnow()
+            )            
+            raise ImportException(detail=e.args[0])
         pass
 
 
-    def create_execution_request(self, user: get_user_model, func_name: str, input_params: dict, resource=None) -> str:
+    def create_execution_request(self, user: get_user_model, func_name: str, step: str, input_params: dict, resource=None) -> str:
         '''
         Create an execution request for the user. Return the UUID of the request
         '''
@@ -52,12 +72,13 @@ class ImportOrchestrator:
             user=user,
             geonode_resource=resource,
             func_name=func_name,
+            step=step,
             input_params=input_params
         )
         return execution.exec_id
     
-    def update_execution_request(self, execution_id, **kwargs):
-        ExecutionRequest.objects.update(uuid=execution_id).update(**kwargs)
+    def update_execution_request_status(self, execution_id, **kwargs):
+        ExecutionRequest.objects.filter(exec_id=execution_id).update(**kwargs)
 
     def _get_execution_object(self, exec_id):
         req = ExecutionRequest.objects.filter(exec_id=exec_id).first()

--- a/importer/orchestrator.py
+++ b/importer/orchestrator.py
@@ -1,0 +1,66 @@
+from django.contrib.auth import get_user_model
+from geonode.resource.models import ExecutionRequest
+from importer.api.exception import ImportException
+from importer.handlers import GPKGStepHandler
+
+
+class ImportOrchestrator:
+    SUPPORTED_TYPES = {
+        "gpkg": GPKGStepHandler
+        #"vector": VectorFileHandler
+    }
+
+    def __init__(self, enable_legacy_upload_status=True) -> None:
+        self.enable_legacy_upload_status = enable_legacy_upload_status
+
+    @property
+    def get_supported_type_list(self):
+        '''
+        Returns the supported types for the import
+        '''
+        return self.SUPPORTED_TYPES.keys()
+
+    def get_file_handler(self, file_type):
+        '''
+        Returns the supported types for the import
+        '''
+        return self.SUPPORTED_TYPES.get(file_type)
+
+    def perform_next_import_step(self, resource_type, execution_id):
+        # Getting the execution object
+        _exec = self._get_execution_object(str(execution_id))
+        # retrieve the task list for the resource_type
+        tasks = self.get_file_handler(resource_type).TASKS_LIST
+        # getting the index
+        _index = tasks.index(_exec.input_params.get('step'))+1
+        # finding in the task_list the last step done
+        remaining_tasks = tasks[_index:] if not _index > len(tasks) else []
+        # getting the next step to perform
+        next_step = next(iter(remaining_tasks))
+        if not next_step:
+            return
+        from importer.views import app as celery_app
+        print(celery_app)
+        pass
+
+
+    def create_execution_request(self, user: get_user_model, func_name: str, input_params: dict, resource=None) -> str:
+        '''
+        Create an execution request for the user. Return the UUID of the request
+        '''
+        execution = ExecutionRequest.objects.create(
+            user=user,
+            geonode_resource=resource,
+            func_name=func_name,
+            input_params=input_params
+        )
+        return execution.exec_id
+    
+    def update_execution_request(self, execution_id, **kwargs):
+        ExecutionRequest.objects.update(uuid=execution_id).update(**kwargs)
+
+    def _get_execution_object(self, exec_id):
+        req = ExecutionRequest.objects.filter(exec_id=exec_id).first()
+        if req is None:
+            raise ImportException("The selected UUID does not exists")
+        return req

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -1,0 +1,115 @@
+import tastypie.compat
+import uuid
+import PIL
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase
+from geonode.tests.base import GeoNodeBaseTestSupport
+from django.urls import reverse
+from unittest.mock import MagicMock, patch
+from importer.api.exception import ImportException
+from importer.handlers import AbstractHandler, GPKGFileHandler
+from importer.orchestrator import SUPPORTED_TYPES, ImportOrchestrator
+
+from importer.views import import_orchestrator
+from geonode.resource.models import ExecutionRequest
+# Create your tests here.
+
+
+class TestCeleryTasks(GeoNodeBaseTestSupport):
+
+    @patch("importer.views.importer.perform_next_import_step")
+    def test_import_orchestrator_create_exececution_request_if_none(self, importer):
+        user = get_user_model().objects.first()
+        count = ExecutionRequest.objects.count()
+
+        import_orchestrator(
+            files={"base_file": "/tmp/file.txt"},
+            store_spatial_files=True,
+            user=user.username,
+            execution_id=None
+        )
+
+        self.assertEqual(count+1, ExecutionRequest.objects.count())
+        importer.assert_called_once()
+
+
+    @patch("importer.views.importer.perform_next_import_step")
+    def test_import_orchestrator_dont_create_exececution_request_if_not__none(self, importer):
+        user = get_user_model().objects.first()
+        count = ExecutionRequest.objects.count()
+
+        import_orchestrator(
+            files={"base_file": "/tmp/file.txt"},
+            store_spatial_files=True,
+            user=user.username,
+            execution_id="some value"
+        )
+
+        self.assertEqual(count, ExecutionRequest.objects.count())
+        importer.assert_called_once()
+
+
+class TestsImporterOrchestrator(GeoNodeBaseTestSupport):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.importer = ImportOrchestrator()
+    
+    def test_get_supported_type_list(self):
+        actual = self.importer.supported_type
+        self.assertEqual(SUPPORTED_TYPES.keys(), actual)
+
+    @patch("importer.orchestrator.SUPPORTED_TYPES")
+    def test_get_file_handler_raise_error_if_not_exists(self, supported_types):
+        supported_types.get.return_value = {}
+        with self.assertRaises(ImportException) as _exc:
+            self.importer.get_file_handler('invalid_type')
+        self.assertEqual(str(_exc.exception.detail), "The requested filetype is not supported: invalid_type")
+
+    @patch("importer.orchestrator.SUPPORTED_TYPES")
+    def test_get_file_handler(self, supported_types):
+        supported_types.get.return_value = {
+            "gpkg": GPKGFileHandler()
+        }
+        actual = self.importer.get_file_handler('gpkg')
+        self.assertIsInstance(actual.get('gpkg'), AbstractHandler)
+
+    def test_get_execution_object_raise_exp_if_not_exists(self):
+        with self.assertRaises(ImportException) as _exc:
+            self.importer.get_execution_object(str(uuid.uuid4()))
+        
+        self.assertEqual(str(_exc.exception.detail), "The selected UUID does not exists")
+
+    def test_get_execution_object_retrun_exp(self):
+        _uuid = str(uuid.uuid4())
+        ExecutionRequest.objects.create(
+            exec_id=_uuid,
+            func_name="test"
+        )
+        try:
+            _exec = self.importer.get_execution_object(_uuid)
+            self.assertIsNotNone(_exec)
+        finally:
+            ExecutionRequest.objects.filter(exec_id=_uuid).delete()
+
+    def test_create_execution_request(self):
+        handler = self.importer.get_file_handler('gpkg')
+        count = ExecutionRequest.objects.count()
+        input_files = {
+            "files": {"base_file": "/tmp/file.txt"},
+            "store_spatial_files": True
+        }
+        exec_id = self.importer.create_execution_request(
+            user=get_user_model().objects.first(),
+            func_name=next(iter(handler.TASKS_LIST)),
+            step=next(iter(handler.TASKS_LIST)),
+            input_params={
+                "files": {"base_file": "/tmp/file.txt"},
+                "store_spatial_files": True
+            }
+        )
+        exec_obj = ExecutionRequest.objects.filter(exec_id=exec_id).first()
+        self.assertEqual(count+1, ExecutionRequest.objects.count())
+        self.assertDictEqual(input_files, exec_obj.input_params)
+        self.assertEqual(exec_obj.STATUS_READY, exec_obj.status)

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -1,22 +1,19 @@
-import tastypie.compat
 import uuid
-import PIL
 from django.contrib.auth import get_user_model
-from django.test import SimpleTestCase
 from geonode.tests.base import GeoNodeBaseTestSupport
-from django.urls import reverse
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from importer.api.exception import ImportException
 from importer.handlers import AbstractHandler, GPKGFileHandler
 from importer.orchestrator import SUPPORTED_TYPES, ImportOrchestrator
+from geonode.upload.models import Upload
 
 from importer.views import import_orchestrator
 from geonode.resource.models import ExecutionRequest
+
 # Create your tests here.
 
 
 class TestCeleryTasks(GeoNodeBaseTestSupport):
-
     @patch("importer.views.importer.perform_next_import_step")
     def test_import_orchestrator_create_exececution_request_if_none(self, importer):
         user = get_user_model().objects.first()
@@ -26,15 +23,16 @@ class TestCeleryTasks(GeoNodeBaseTestSupport):
             files={"base_file": "/tmp/file.txt"},
             store_spatial_files=True,
             user=user.username,
-            execution_id=None
+            execution_id=None,
         )
 
-        self.assertEqual(count+1, ExecutionRequest.objects.count())
+        self.assertEqual(count + 1, ExecutionRequest.objects.count())
         importer.assert_called_once()
 
-
     @patch("importer.views.importer.perform_next_import_step")
-    def test_import_orchestrator_dont_create_exececution_request_if_not__none(self, importer):
+    def test_import_orchestrator_dont_create_exececution_request_if_not__none(
+        self, importer
+    ):
         user = get_user_model().objects.first()
         count = ExecutionRequest.objects.count()
 
@@ -42,7 +40,7 @@ class TestCeleryTasks(GeoNodeBaseTestSupport):
             files={"base_file": "/tmp/file.txt"},
             store_spatial_files=True,
             user=user.username,
-            execution_id="some value"
+            execution_id="some value",
         )
 
         self.assertEqual(count, ExecutionRequest.objects.count())
@@ -50,12 +48,11 @@ class TestCeleryTasks(GeoNodeBaseTestSupport):
 
 
 class TestsImporterOrchestrator(GeoNodeBaseTestSupport):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.importer = ImportOrchestrator()
-    
+
     def test_get_supported_type_list(self):
         actual = self.importer.supported_type
         self.assertEqual(SUPPORTED_TYPES.keys(), actual)
@@ -64,29 +61,29 @@ class TestsImporterOrchestrator(GeoNodeBaseTestSupport):
     def test_get_file_handler_raise_error_if_not_exists(self, supported_types):
         supported_types.get.return_value = {}
         with self.assertRaises(ImportException) as _exc:
-            self.importer.get_file_handler('invalid_type')
-        self.assertEqual(str(_exc.exception.detail), "The requested filetype is not supported: invalid_type")
+            self.importer.get_file_handler("invalid_type")
+        self.assertEqual(
+            str(_exc.exception.detail),
+            "The requested filetype is not supported: invalid_type",
+        )
 
     @patch("importer.orchestrator.SUPPORTED_TYPES")
     def test_get_file_handler(self, supported_types):
-        supported_types.get.return_value = {
-            "gpkg": GPKGFileHandler()
-        }
-        actual = self.importer.get_file_handler('gpkg')
-        self.assertIsInstance(actual.get('gpkg'), AbstractHandler)
+        supported_types.get.return_value = {"gpkg": GPKGFileHandler()}
+        actual = self.importer.get_file_handler("gpkg")
+        self.assertIsInstance(actual.get("gpkg"), AbstractHandler)
 
     def test_get_execution_object_raise_exp_if_not_exists(self):
         with self.assertRaises(ImportException) as _exc:
             self.importer.get_execution_object(str(uuid.uuid4()))
-        
-        self.assertEqual(str(_exc.exception.detail), "The selected UUID does not exists")
+
+        self.assertEqual(
+            str(_exc.exception.detail), "The selected UUID does not exists"
+        )
 
     def test_get_execution_object_retrun_exp(self):
         _uuid = str(uuid.uuid4())
-        ExecutionRequest.objects.create(
-            exec_id=_uuid,
-            func_name="test"
-        )
+        ExecutionRequest.objects.create(exec_id=_uuid, func_name="test")
         try:
             _exec = self.importer.get_execution_object(_uuid)
             self.assertIsNotNone(_exec)
@@ -94,11 +91,11 @@ class TestsImporterOrchestrator(GeoNodeBaseTestSupport):
             ExecutionRequest.objects.filter(exec_id=_uuid).delete()
 
     def test_create_execution_request(self):
-        handler = self.importer.get_file_handler('gpkg')
+        handler = self.importer.get_file_handler("gpkg")
         count = ExecutionRequest.objects.count()
         input_files = {
             "files": {"base_file": "/tmp/file.txt"},
-            "store_spatial_files": True
+            "store_spatial_files": True,
         }
         exec_id = self.importer.create_execution_request(
             user=get_user_model().objects.first(),
@@ -106,67 +103,70 @@ class TestsImporterOrchestrator(GeoNodeBaseTestSupport):
             step=next(iter(handler.TASKS_LIST)),
             input_params={
                 "files": {"base_file": "/tmp/file.txt"},
-                "store_spatial_files": True
-            }
+                "store_spatial_files": True,
+            },
         )
         exec_obj = ExecutionRequest.objects.filter(exec_id=exec_id).first()
-        self.assertEqual(count+1, ExecutionRequest.objects.count())
+        self.assertEqual(count + 1, ExecutionRequest.objects.count())
         self.assertDictEqual(input_files, exec_obj.input_params)
         self.assertEqual(exec_obj.STATUS_READY, exec_obj.status)
+        # check that also the legacy is created
+        self.assertIsNotNone(Upload.objects.get(metadata__icontains=exec_id))
 
     @patch("importer.orchestrator.app.tasks.get")
     def test_perform_next_import_step(self, mock_celery):
         # setup test
-        handler = self.importer.get_file_handler('gpkg')
+        handler = self.importer.get_file_handler("gpkg")
         _id = self.importer.create_execution_request(
             user=get_user_model().objects.first(),
             func_name=next(iter(handler.TASKS_LIST)),
-            step="start_import", # adding the first step for the GPKG file
+            step="start_import",  # adding the first step for the GPKG file
             input_params={
                 "files": {"base_file": "/tmp/file.txt"},
-                "store_spatial_files": True
-            }
+                "store_spatial_files": True,
+            },
         )
         # test under tests
-        self.importer.perform_next_import_step('gpkg', _id)
+        self.importer.perform_next_import_step("gpkg", _id)
         mock_celery.assert_called_once()
         mock_celery.assert_called_with("importer.import_resource")
 
     @patch("importer.orchestrator.app.tasks.get")
     def test_perform_last_import_step(self, mock_celery):
         # setup test
-        handler = self.importer.get_file_handler('gpkg')
+        handler = self.importer.get_file_handler("gpkg")
         _id = self.importer.create_execution_request(
             user=get_user_model().objects.first(),
             func_name=next(iter(handler.TASKS_LIST)),
-            step="importer.create_gn_resource", # adding the first step for the GPKG file
+            step="importer.create_gn_resource",  # adding the first step for the GPKG file
             input_params={
                 "files": {"base_file": "/tmp/file.txt"},
-                "store_spatial_files": True
-            }
+                "store_spatial_files": True,
+            },
         )
         # test under tests
-        self.importer.perform_next_import_step('gpkg', _id)
+        self.importer.perform_next_import_step("gpkg", _id)
         mock_celery.assert_not_called()
 
     @patch("importer.orchestrator.app.tasks.get")
     def test_perform_with_error_set_invalid_status(self, mock_celery):
         mock_celery.side_effect = Exception("test exception")
         # setup test
-        handler = self.importer.get_file_handler('gpkg')
+        handler = self.importer.get_file_handler("gpkg")
         _id = self.importer.create_execution_request(
             user=get_user_model().objects.first(),
             func_name=next(iter(handler.TASKS_LIST)),
-            step="start_import", # adding the first step for the GPKG file
+            step="start_import",  # adding the first step for the GPKG file
             input_params={
                 "files": {"base_file": "/tmp/file.txt"},
-                "store_spatial_files": True
-            }
+                "store_spatial_files": True,
+            },
         )
         # test under tests
         with self.assertRaises(Exception):
-            self.importer.perform_next_import_step('gpkg', _id)
-        
+            self.importer.perform_next_import_step("gpkg", _id)
+
         _excec = ExecutionRequest.objects.filter(exec_id=_id).first()
         self.assertIsNotNone(_excec)
         self.assertEqual(ExecutionRequest.STATUS_FAILED, _excec.status)
+        self.assertIsNotNone(Upload.objects.get(metadata__icontains=_id))

--- a/importer/views.py
+++ b/importer/views.py
@@ -26,7 +26,7 @@ importer = ImportOrchestrator()
     retry_jitter=False
 )
 def import_orchestrator(self, files, store_spatial_files=True, user=None, execution_id=None):
-    # TODO: get filetybe by the files
+    # TODO: get filetype by the files
     handler = importer.get_file_handler('gpkg')
 
     if execution_id is None:
@@ -66,7 +66,7 @@ def import_resource(self, resource_type, execution_id):
         func_name="import_resource",
         step="importer.import_resource"
     )
-    _exec = importer._get_execution_object(execution_id)
+    _exec = importer.get_execution_object(execution_id)
 
     _files = _exec.input_params.get("files")
     _store_spatial_files = _exec.input_params.get("files")
@@ -77,7 +77,6 @@ def import_resource(self, resource_type, execution_id):
     # starting file validation
 
     # do something
-
 
     #at the end recall the import_orchestrator for the next step
     import_orchestrator.apply_async(

--- a/importer/views.py
+++ b/importer/views.py
@@ -1,13 +1,17 @@
 from celery import Celery
+from django.contrib.auth import get_user_model
 from geonode.tasks.tasks import FaultTolerantTask
+from importer.orchestrator import ImportOrchestrator
 
 
 app = Celery('importer')
 
+
+
 @app.task(
     bind=True,
     base=FaultTolerantTask,
-    name='importer.run_dataset_import',
+    name='importer.start_dataset_import',
     queue='geonode.dataset_importer',
     expires=600,
     time_limit=600,
@@ -18,5 +22,40 @@ app = Celery('importer')
     retry_backoff_max=30,
     retry_jitter=False
 )
-def run_dataset_import(self, data, store_spatial_files, execution_id=None):
+def start_dataset_import(self, files, store_spatial_files, user, execution_id=None):
+    importer = ImportOrchestrator()
+
+    handler = importer.get_file_handler('gpkg')
+
+    if execution_id is None:
+        execution_id = importer.create_execution_request(
+            user=get_user_model().objects.get(username=user),
+            func_name="start_dataset_import",
+            input_params={
+                "step": next(iter(handler.TASKS_LIST)),
+                "files": files,
+                "store_spatial_files": store_spatial_files
+            }
+        )
+
+    importer.perform_next_import_step(resource_type="gpkg", execution_id=execution_id)
+
+
+
+
+@app.task(
+    bind=True,
+    base=FaultTolerantTask,
+    name='importer.import_resource',
+    queue='geonode.dataset_importer',
+    expires=600,
+    time_limit=600,
+    acks_late=False,
+    autoretry_for=(Exception, ),
+    retry_kwargs={'max_retries': 3},
+    retry_backoff=3,
+    retry_backoff_max=30,
+    retry_jitter=False
+)
+def import_resource(self, execution_id):
     pass

--- a/importer/views.py
+++ b/importer/views.py
@@ -14,8 +14,8 @@ importer = ImportOrchestrator()
 @app.task(
     bind=True,
     base=FaultTolerantTask,
-    name='importer.import_derivator',
-    queue='importer.import_derivator',
+    name='importer.import_orchestrator',
+    queue='importer.import_orchestrator',
     expires=600,
     time_limit=600,
     acks_late=False,
@@ -25,7 +25,7 @@ importer = ImportOrchestrator()
     retry_backoff_max=30,
     retry_jitter=False
 )
-def import_derivator(self, files, store_spatial_files=True, user=None, execution_id=None):
+def import_orchestrator(self, files, store_spatial_files=True, user=None, execution_id=None):
     # TODO: get filetybe by the files
     handler = importer.get_file_handler('gpkg')
 
@@ -79,8 +79,8 @@ def import_resource(self, resource_type, execution_id):
     # do something
 
 
-    #at the end recall the import_derivator for the next step
-    import_derivator.apply_async(
+    #at the end recall the import_orchestrator for the next step
+    import_orchestrator.apply_async(
                     (_files, _store_spatial_files, _user.username, execution_id)
                 )
     pass

--- a/importer/views.py
+++ b/importer/views.py
@@ -1,13 +1,11 @@
-from celery import Celery
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from geonode.resource.models import ExecutionRequest
 from geonode.tasks.tasks import FaultTolerantTask
-
+from importer.celery_app import app
 from importer.datastore import DataStoreManager
 from importer.orchestrator import ImportOrchestrator
 
-app = Celery('importer')
 importer = ImportOrchestrator()
 
 


### PR DESCRIPTION
- Add new Queued required to let the async import work
- rename `run_dataset_import` to `import_orchestrator`
- Creation of basic DataStoreManager (it will be improved in the next PRs)
- Creation of basic `GPKGFileHandler`:
-- Contains the list of the tasks that need to be run for that specific filetype (Vector/raster/other)
-- Contains the validation needed to consider the upload valid
- `ImportOrchestrator`: will be responsible for handling the whole import phase 
-- the function `perform_next_import_step` given an execution_request_id will decide which will be the next step to perform for the input resource type
-- handle the basic execution status update
- define the basic async task used to call the orchestrator
- define the basic async task for the import phase
- Test coverage