### PR TITLE
[Fixes #133] injected app are not coherent with the handlers registered

### DIFF
--- a/importer/apps.py
+++ b/importer/apps.py
@@ -18,7 +18,6 @@ def run_setup_hooks(*args, **kwargs):
     """
     from django.conf.urls import include, url
     from geonode.urls import urlpatterns
-    from django.conf import settings
 
     url_already_injected = any(
         [
@@ -32,62 +31,4 @@ def run_setup_hooks(*args, **kwargs):
         urlpatterns.insert(
             0,
             url(r"^api/v2/", include("importer.api.urls")),
-        )
-
-    # injecting the new config required for FE
-    gpkg_config = [
-        {"id": "gpkg", "label": "GeoPackage", "format": "archive", "ext": ["gpkg"]},
-        {"id": "kml", "label": "KML/KMZ", "format": "archive", "ext": ["kml", "kmz"]},
-        {
-            "id": "geojson",
-            "label": "GeoJson",
-            "format": "metadata",
-            "ext": ["json", "geojson"],
-            "optional": ["xml", "sld"],
-        },
-        {
-            "id": "xml",
-            "label": "XML Metadata File",
-            "format": "metadata",
-            "ext": ["xml"],
-            "mimeType": ["application/json"],
-            "needsFiles": [
-                "shp",
-                "prj",
-                "dbf",
-                "shx",
-                "csv",
-                "tiff",
-                "zip",
-                "sld",
-                "geojson",
-            ],
-        },
-        {
-            "id": "sld",
-            "label": "Styled Layer Descriptor (SLD)",
-            "format": "metadata",
-            "ext": ["sld"],
-            "mimeType": ["application/json"],
-            "needsFiles": [
-                "shp",
-                "prj",
-                "dbf",
-                "shx",
-                "csv",
-                "tiff",
-                "zip",
-                "xml",
-                "geojson",
-            ],
-        },
-    ]
-    if not getattr(settings, "ADDITIONAL_DATASET_FILE_TYPES", None):
-        setattr(settings, "ADDITIONAL_DATASET_FILE_TYPES", gpkg_config)
-    elif "gpkg" not in [x.get("id") for x in settings.ADDITIONAL_DATASET_FILE_TYPES]:
-        settings.ADDITIONAL_DATASET_FILE_TYPES.extend(gpkg_config)
-        setattr(
-            settings,
-            "ADDITIONAL_DATASET_FILE_TYPES",
-            settings.ADDITIONAL_DATASET_FILE_TYPES,
         )

--- a/importer/handlers/apps.py
+++ b/importer/handlers/apps.py
@@ -23,3 +23,57 @@ def run_setup_hooks(*args, **kwargs):
         _handlers = [import_string(module_path) for module_path in settings.IMPORTER_HANDLERS]
         list(map(lambda item: item.register(), _handlers))
         logger.info(f"The following handlers have been registered: {', '.join(settings.IMPORTER_HANDLERS)}")
+
+        _available_settings = [
+            import_string(module_path)().supported_file_extension_config
+            for module_path in settings.IMPORTER_HANDLERS
+        ]
+        # injecting the new config required for FE
+        supported_type = [
+            {
+                "id": "xml",
+                "label": "XML Metadata File",
+                "format": "metadata",
+                "ext": ["xml"],
+                "mimeType": ["application/json"],
+                "needsFiles": [
+                    "shp",
+                    "prj",
+                    "dbf",
+                    "shx",
+                    "csv",
+                    "tiff",
+                    "zip",
+                    "sld",
+                    "geojson",
+                ],
+            },
+            {
+                "id": "sld",
+                "label": "Styled Layer Descriptor (SLD)",
+                "format": "metadata",
+                "ext": ["sld"],
+                "mimeType": ["application/json"],
+                "needsFiles": [
+                    "shp",
+                    "prj",
+                    "dbf",
+                    "shx",
+                    "csv",
+                    "tiff",
+                    "zip",
+                    "xml",
+                    "geojson",
+                ],
+            },
+        ]
+        supported_type.extend(_available_settings)
+        if not getattr(settings, "ADDITIONAL_DATASET_FILE_TYPES", None):
+            setattr(settings, "ADDITIONAL_DATASET_FILE_TYPES", supported_type)
+        elif "gpkg" not in [x.get("id") for x in settings.ADDITIONAL_DATASET_FILE_TYPES]:
+            settings.ADDITIONAL_DATASET_FILE_TYPES.extend(supported_type)
+            setattr(
+                settings,
+                "ADDITIONAL_DATASET_FILE_TYPES",
+                settings.ADDITIONAL_DATASET_FILE_TYPES,
+            )

--- a/importer/handlers/base.py
+++ b/importer/handlers/base.py
@@ -47,6 +47,14 @@ class BaseHandler(ABC):
             raise Exception("The requested action is not implemented yet")
         return cls.ACTIONS.get(action)
 
+    @property
+    def default_geometry_column_name(self):
+        return "geometry"
+
+    @property
+    def supported_file_extension_config(self):
+        return NotImplementedError
+
     @staticmethod
     def is_valid(files, user):
         """

--- a/importer/handlers/common/raster.py
+++ b/importer/handlers/common/raster.py
@@ -41,6 +41,10 @@ class BaseRasterFileHandler(BaseHandler):
     def default_geometry_column_name(self):
         return "geometry"
 
+    @property
+    def supported_file_extension_config(self):
+        return NotImplementedError
+
     @staticmethod
     def is_valid(files, user):
         """

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -47,6 +47,10 @@ class BaseVectorFileHandler(BaseHandler):
     def default_geometry_column_name(self):
         return "geometry"
 
+    @property
+    def supported_file_extension_config(self):
+        return NotImplementedError
+
     @staticmethod
     def is_valid(files, user):
         """

--- a/importer/handlers/geojson/handler.py
+++ b/importer/handlers/geojson/handler.py
@@ -33,6 +33,16 @@ class GeoJsonFileHandler(BaseVectorFileHandler):
         ),
     }
 
+    @property
+    def supported_file_extension_config(self):
+        return {
+            "id": "geojson",
+            "label": "GeoJson",
+            "format": "metadata",
+            "ext": ["json", "geojson"],
+            "optional": ["xml", "sld"],
+        }
+
     @staticmethod
     def can_handle(_data) -> bool:
         """

--- a/importer/handlers/geotiff/handler.py
+++ b/importer/handlers/geotiff/handler.py
@@ -30,6 +30,17 @@ class GeoTiffFileHandler(BaseRasterFileHandler):
         ),
     }
 
+    @property
+    def supported_file_extension_config(self):
+        return {
+            "id": 'tiff',
+            "label": 'GeoTIFF',
+            "format": 'raster',
+            "ext": ['tiff', 'tif'],
+            "mimeType": ['image/tiff'],
+            "optional": ['xml', 'sld']
+        }
+
     @staticmethod
     def can_handle(_data) -> bool:
         """

--- a/importer/handlers/gpkg/handler.py
+++ b/importer/handlers/gpkg/handler.py
@@ -34,6 +34,10 @@ class GPKGFileHandler(BaseVectorFileHandler):
         ),
     }
 
+    @property
+    def supported_file_extension_config(self):
+        return {"id": "gpkg", "label": "GeoPackage", "format": "archive", "ext": ["gpkg"]}
+
     @staticmethod
     def can_handle(_data) -> bool:
         """

--- a/importer/handlers/kml/handler.py
+++ b/importer/handlers/kml/handler.py
@@ -33,6 +33,10 @@ class KMLFileHandler(BaseVectorFileHandler):
         ),
     }
 
+    @property
+    def supported_file_extension_config(self):
+        return {"id": "kml", "label": "KML/KMZ", "format": "archive", "ext": ["kml", "kmz"]}
+
     @staticmethod
     def can_handle(_data) -> bool:
         """

--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -35,6 +35,17 @@ class ShapeFileHandler(BaseVectorFileHandler):
         ),
     }
 
+    @property
+    def supported_file_extension_config(self):
+        return {
+            "id": 'shp',
+            "label": 'ESRI Shapefile',
+            "format": 'vector',
+            "ext": ['shp'],
+            "requires": ['shp', 'prj', 'dbf', 'shx'],
+            "optional": ['xml', 'sld']
+        }
+
     @staticmethod
     def can_handle(_data) -> bool:
         """


### PR DESCRIPTION
The settings needed for the FE are now based on the handlers registered in the settings.

Each handler will provide the settings needed to correctly register his data. The XML and SLD can stay static