### PR TITLE
[Fixes #132] Improve dataset overwrite workflow

### DIFF
--- a/importer/api/serializer.py
+++ b/importer/api/serializer.py
@@ -14,7 +14,7 @@ class ImporterSerializer(DynamicModelSerializer):
             "xml_file",
             "sld_file",
             "store_spatial_files",
-            "override_existing_layer",
+            "overwrite_existing_layer",
             "skip_existing_layers",
         )
 
@@ -22,5 +22,5 @@ class ImporterSerializer(DynamicModelSerializer):
     xml_file = serializers.FileField(required=False)
     sld_file = serializers.FileField(required=False)
     store_spatial_files = serializers.BooleanField(required=False, default=True)
-    override_existing_layer = serializers.BooleanField(required=False, default=False)
+    overwrite_existing_layer = serializers.BooleanField(required=False, default=False)
     skip_existing_layers = serializers.BooleanField(required=False, default=False)

--- a/importer/api/views.py
+++ b/importer/api/views.py
@@ -151,6 +151,7 @@ class ImporterViewSet(DynamicModelViewSet):
                     legacy_upload_name=_file.name,
                     action=action,
                     name=_file.name,
+                    source='upload'
                 )
 
                 sig = import_orchestrator.s(
@@ -239,6 +240,7 @@ class ResourceImporter(DynamicModelViewSet):
                     **{"handler_module_path": handler_module_path},
                     **extracted_params,
                 },
+                source="importer_copy"
             )
 
             sig = import_orchestrator.s(

--- a/importer/celery_tasks.py
+++ b/importer/celery_tasks.py
@@ -212,7 +212,7 @@ def publish_resource(
         )
         if data:
             # we should not publish resource without a crs
-            if not _overwrite:
+            if not _overwrite or (_overwrite and not _publisher.get_resource(alternate)):
                 _publisher.publish_resources(data)
             else:
                 _publisher.overwrite_resources(data)

--- a/importer/celery_tasks.py
+++ b/importer/celery_tasks.py
@@ -454,7 +454,7 @@ def create_dynamic_structure(
                 f"Error during the field creation. The field or class_name is None {field} for {layer_name} for execution {execution_id}"
             )
             raise InvalidFieldNameError(
-                f"Error during the field creation. The field or class_name is None {field} for {layer_name}  for execution {execution_id}"
+                f"Error during the field creation. The field or class_name is None {field} for {layer_name} for execution {execution_id}"
             )
 
         _kwargs = {"null": field.get("null", True)}

--- a/importer/handlers/base.py
+++ b/importer/handlers/base.py
@@ -138,7 +138,7 @@ class BaseHandler(ABC):
         return NotImplementedError
 
     def get_ogr2ogr_task_group(
-        self, execution_id, files, layer, should_be_overrided, alternate
+        self, execution_id, files, layer, should_be_overwritten, alternate
     ):
         """
         implement custom ogr2ogr task group

--- a/importer/handlers/base.py
+++ b/importer/handlers/base.py
@@ -89,7 +89,8 @@ class BaseHandler(ABC):
     def fixup_name(self, name):
         return name.lower().replace("-", "_")\
             .replace(" ", "_").replace(")", "")\
-            .replace("(", "").replace(",", "").replace("&", "")
+            .replace("(", "").replace(",", "")\
+            .replace("&", "").replace(".", "")
 
     def extract_resource_to_publish(self, files, layer_name, alternate, **kwargs):
         """

--- a/importer/handlers/common/raster.py
+++ b/importer/handlers/common/raster.py
@@ -276,7 +276,7 @@ class BaseRasterFileHandler(BaseHandler):
             "DEFAULT_WORKSPACE",
             getattr(settings, "CASCADE_WORKSPACE", "geonode"),
         )
-        
+
         _overwrite = _exec.input_params.get("overwrite_existing_layer", False)
         # if the layer exists, we just update the information of the dataset by
         # let it recreate the catalogue
@@ -290,8 +290,7 @@ class BaseRasterFileHandler(BaseHandler):
             defaults=dict(
                 name=alternate,
                 workspace=workspace,
-                store=os.environ.get("GEONODE_GEODATABASE", "geonode_data"),
-                subtype="vector",
+                subtype="raster",
                 alternate=f"{workspace}:{alternate}",
                 dirty_state=True,
                 title=layer_name,
@@ -311,21 +310,21 @@ class BaseRasterFileHandler(BaseHandler):
 
         saved_dataset.refresh_from_db()
         return saved_dataset
-    
+
     def overwrite_geonode_resource(
         self, layer_name: str, alternate: str, execution_id: str, resource_type: Dataset = Dataset, files=None
     ):
-        
+
         dataset = resource_type.objects.filter(alternate__icontains=alternate)
 
         _exec = self._get_execution_request_object(execution_id)
-        
+
         _overwrite = _exec.input_params.get("overwrite_existing_layer", False)
         # if the layer exists, we just update the information of the dataset by
         # let it recreate the catalogue
         if dataset.exists() and _overwrite:
             dataset = dataset.first()
-            
+
             resource_manager.update(dataset.uuid, instance=dataset)
 
             dataset.refresh_from_db()
@@ -336,10 +335,10 @@ class BaseRasterFileHandler(BaseHandler):
             dataset.refresh_from_db()
             return dataset
         elif not dataset.exists() and _overwrite:
-                logger.warning(
-                    f"The dataset required {alternate} does not exists, but an overwrite is required, the resource will be created"
-                )
-                return self.create_geonode_resource(layer_name, alternate, execution_id, resource_type, files)
+            logger.warning(
+                f"The dataset required {alternate} does not exists, but an overwrite is required, the resource will be created"
+            )
+            return self.create_geonode_resource(layer_name, alternate, execution_id, resource_type, files)
         elif not dataset.exists() and not _overwrite:
             logger.warning(
                 "The resource does not exists, please use 'create_geonode_resource' to create one"

--- a/importer/handlers/common/raster.py
+++ b/importer/handlers/common/raster.py
@@ -96,7 +96,7 @@ class BaseRasterFileHandler(BaseHandler):
 
         return {
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),
-            "override_existing_layer": _data.pop("override_existing_layer", "False"),
+            "overwrite_existing_layer": _data.pop("overwrite_existing_layer", "False"),
             "store_spatial_file": _data.pop("store_spatial_files", "True"),
         }, _data
 
@@ -214,7 +214,7 @@ class BaseRasterFileHandler(BaseHandler):
             # start looping on the layers available
             layer_name = self.fixup_name(filename)
 
-            should_be_overrided = _exec.input_params.get("override_existing_layer")
+            should_be_overwritten = _exec.input_params.get("overwrite_existing_layer")
             # should_be_imported check if the user+layername already exists or not
             if (
                 should_be_imported(
@@ -223,7 +223,7 @@ class BaseRasterFileHandler(BaseHandler):
                     skip_existing_layer=_exec.input_params.get(
                         "skip_existing_layer"
                     ),
-                    override_existing_layer=should_be_overrided,
+                    overwrite_existing_layer=should_be_overwritten,
                 )
             ):
                 workspace = get_geoserver_cascading_workspace(create=False)
@@ -233,7 +233,7 @@ class BaseRasterFileHandler(BaseHandler):
 
                 dataset_exists = user_datasets.exists()
 
-                if dataset_exists and should_be_overrided:
+                if dataset_exists and should_be_overwritten:
                     layer_name, alternate = layer_name, user_datasets.first().alternate
                 else:
                     alternate = create_alternate(layer_name, execution_id)
@@ -272,32 +272,29 @@ class BaseRasterFileHandler(BaseHandler):
             "DEFAULT_WORKSPACE",
             getattr(settings, "CASCADE_WORKSPACE", "geonode"),
         )
+        
+        _overwrite = _exec.input_params.get("overwrite_existing_layer", False)
         # if the layer exists, we just update the information of the dataset by
         # let it recreate the catalogue
-        if saved_dataset.exists():
-            saved_dataset = saved_dataset.first()
-        else:
-            # if it not exists, we create it from scratch
-            if not saved_dataset.exists() and _exec.input_params.get(
-                "override_existing_layer", False
-            ):
-                logger.warning(
-                    f"The dataset required {alternate} does not exists, but an overwrite is required, the resource will be created"
-                )
-            saved_dataset = resource_manager.create(
-                None,
-                resource_type=resource_type,
-                defaults=dict(
-                    name=alternate,
-                    workspace=workspace,
-                    subtype="raster",
-                    alternate=f"{workspace}:{alternate}",
-                    dirty_state=True,
-                    title=layer_name,
-                    owner=_exec.user,
-                    files=list(set(list(_exec.input_params.get("files", {}).values()) or list(files))),
-                ),
+        if not saved_dataset.exists() and _overwrite:
+            logger.warning(
+                f"The dataset required {alternate} does not exists, but an overwrite is required, the resource will be created"
             )
+        saved_dataset = resource_manager.create(
+            None,
+            resource_type=resource_type,
+            defaults=dict(
+                name=alternate,
+                workspace=workspace,
+                store=os.environ.get("GEONODE_GEODATABASE", "geonode_data"),
+                subtype="vector",
+                alternate=f"{workspace}:{alternate}",
+                dirty_state=True,
+                title=layer_name,
+                owner=_exec.user,
+                files=list(set(list(_exec.input_params.get("files", {}).values()) or list(files))),
+            ),
+        )
 
         saved_dataset.refresh_from_db()
 
@@ -310,6 +307,40 @@ class BaseRasterFileHandler(BaseHandler):
 
         saved_dataset.refresh_from_db()
         return saved_dataset
+    
+    def overwrite_geonode_resource(
+        self, layer_name: str, alternate: str, execution_id: str, resource_type: Dataset = Dataset, files=None
+    ):
+        
+        dataset = resource_type.objects.filter(alternate__icontains=alternate)
+
+        _exec = self._get_execution_request_object(execution_id)
+        
+        _overwrite = _exec.input_params.get("overwrite_existing_layer", False)
+        # if the layer exists, we just update the information of the dataset by
+        # let it recreate the catalogue
+        if dataset.exists() and _overwrite:
+            dataset = dataset.first()
+            
+            resource_manager.update(dataset.uuid, instance=dataset)
+
+            dataset.refresh_from_db()
+
+            self.handle_xml_file(dataset, _exec)
+
+            resource_manager.set_thumbnail(self.object.uuid, instance=self.object, overwrite=False)
+            dataset.refresh_from_db()
+            return dataset
+        elif not dataset.exists() and _overwrite:
+                logger.warning(
+                    f"The dataset required {alternate} does not exists, but an overwrite is required, the resource will be created"
+                )
+                return self.create_geonode_resource(layer_name, alternate, execution_id, resource_type, files)
+        elif not dataset.exists() and not _overwrite:
+            logger.warning(
+                "The resource does not exists, please use 'create_geonode_resource' to create one"
+            )
+        return
 
     def handle_xml_file(self, saved_dataset: Dataset, _exec: ExecutionRequest):
         _path = _exec.input_params.get("files", {}).get("xml_file", "")

--- a/importer/handlers/common/tests_vector.py
+++ b/importer/handlers/common/tests_vector.py
@@ -120,7 +120,7 @@ class TestBaseVectorFileHandler(TestCase):
             dynamic_model, layer_name, celery_group = self.handler.setup_dynamic_model(
                 layer=[x for x in layers][0],
                 execution_id=str(exec_id),
-                should_be_overrided=overwrite,
+                should_be_overwritten=overwrite,
                 username=self.user,
             )
 
@@ -194,7 +194,7 @@ class TestBaseVectorFileHandler(TestCase):
             str(_uuid),
             files=self.valid_files,
             layer="dataset",
-            should_be_overrided=True,
+            should_be_overwritten=True,
             alternate="abc",
         )
         self.assertIsInstance(actual, (Signature,))
@@ -215,7 +215,7 @@ class TestBaseVectorFileHandler(TestCase):
             files=self.valid_files,
             original_name="dataset",
             handler_module_path=str(self.handler),
-            override_layer=False,
+            ovverwrite_layer=False,
             alternate="alternate",
         )
 
@@ -242,7 +242,7 @@ class TestBaseVectorFileHandler(TestCase):
                 files=self.valid_files,
                 original_name="dataset",
                 handler_module_path=str(self.handler),
-                override_layer=False,
+                ovverwrite_layer=False,
                 alternate="alternate",
             )
 

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -362,7 +362,7 @@ class BaseVectorFileHandler(BaseHandler):
             cames here when is a new brand upload or when (for any reasons) the dataset exists but the
             dynamic model has not been created before
             '''
-            #layer_name = create_alternate(layer_name, execution_id)
+            #  layer_name = create_alternate(layer_name, execution_id)
             dynamic_schema = ModelSchema.objects.create(
                 name=layer_name,
                 db_name="datastore",
@@ -464,7 +464,7 @@ class BaseVectorFileHandler(BaseHandler):
             "DEFAULT_WORKSPACE",
             getattr(settings, "CASCADE_WORKSPACE", "geonode"),
         )
-        
+
         _overwrite = _exec.input_params.get("overwrite_existing_layer", False)
         # if the layer exists, we just update the information of the dataset by
         # let it recreate the catalogue
@@ -499,21 +499,21 @@ class BaseVectorFileHandler(BaseHandler):
 
         saved_dataset.refresh_from_db()
         return saved_dataset
-    
+
     def overwrite_geonode_resource(
         self, layer_name: str, alternate: str, execution_id: str, resource_type: Dataset = Dataset, files=None
     ):
-        
+
         dataset = resource_type.objects.filter(alternate__icontains=alternate)
 
         _exec = self._get_execution_request_object(execution_id)
-        
+
         _overwrite = _exec.input_params.get("overwrite_existing_layer", False)
         # if the layer exists, we just update the information of the dataset by
         # let it recreate the catalogue
         if dataset.exists() and _overwrite:
             dataset = dataset.first()
-            
+
             resource_manager.update(dataset.uuid, instance=dataset)
 
             dataset.refresh_from_db()
@@ -524,10 +524,10 @@ class BaseVectorFileHandler(BaseHandler):
             dataset.refresh_from_db()
             return dataset
         elif not dataset.exists() and _overwrite:
-                logger.warning(
-                    f"The dataset required {alternate} does not exists, but an overwrite is required, the resource will be created"
-                )
-                return self.create_geonode_resource(layer_name, alternate, execution_id, resource_type, files)
+            logger.warning(
+                f"The dataset required {alternate} does not exists, but an overwrite is required, the resource will be created"
+            )
+            return self.create_geonode_resource(layer_name, alternate, execution_id, resource_type, files)
         elif not dataset.exists() and not _overwrite:
             logger.warning(
                 "The resource does not exists, please use 'create_geonode_resource' to create one"

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -172,9 +172,9 @@ class BaseVectorFileHandler(BaseHandler):
                 We use the schema editor directly, because the model itself is not managed
                 on creation, but for the delete since we are going to handle, we can use it
                 '''
+                schema.delete()
                 _model_editor = ModelSchemaEditor(initial_model=name, db_name=schema.db_name)
                 _model_editor.drop_table(schema.as_model())
-                schema.delete()
             # Removing Field Schema
         except Exception as e:
             logger.error(f"Error during deletion of Dynamic Model schema: {e.args[0]}")
@@ -520,7 +520,7 @@ class BaseVectorFileHandler(BaseHandler):
 
             self.handle_xml_file(dataset, _exec)
 
-            resource_manager.set_thumbnail(self.object.uuid, instance=self.object, overwrite=False)
+            resource_manager.set_thumbnail(dataset.uuid, instance=dataset, overwrite=False)
             dataset.refresh_from_db()
             return dataset
         elif not dataset.exists() and _overwrite:

--- a/importer/handlers/geojson/handler.py
+++ b/importer/handlers/geojson/handler.py
@@ -81,13 +81,13 @@ class GeoJsonFileHandler(BaseVectorFileHandler):
         return ogr.GetDriverByName("GeoJSON")
 
     @staticmethod
-    def create_ogr2ogr_command(files, original_name, override_layer, alternate):
+    def create_ogr2ogr_command(files, original_name, ovverwrite_layer, alternate):
         """
         Define the ogr2ogr command to be executed.
         This is a default command that is needed to import a vector file
         """
 
         base_command = BaseVectorFileHandler.create_ogr2ogr_command(
-            files, original_name, override_layer, alternate
+            files, original_name, ovverwrite_layer, alternate
         )
         return f"{base_command } -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name}"

--- a/importer/handlers/geojson/tests.py
+++ b/importer/handlers/geojson/tests.py
@@ -119,7 +119,7 @@ class TestGeoJsonFileHandler(TestCase):
             files=self.valid_files,
             original_name="dataset",
             handler_module_path=str(self.handler),
-            override_layer=False,
+            ovverwrite_layer=False,
             alternate="alternate"
         )
 

--- a/importer/handlers/geojson/tests.py
+++ b/importer/handlers/geojson/tests.py
@@ -43,10 +43,10 @@ class TestGeoJsonFileHandler(TestCase):
     def test_task_list_is_the_expected_one_copy(self):
         expected = (
             "start_copy",
-            "importer.copy_geonode_resource",
             "importer.copy_dynamic_model",
             "importer.copy_geonode_data_table",
-            "importer.publish_resource"
+            "importer.publish_resource",
+            "importer.copy_geonode_resource",
         )
         self.assertEqual(len(self.handler.ACTIONS["copy"]), 5)
         self.assertTupleEqual(expected, self.handler.ACTIONS["copy"])

--- a/importer/handlers/gpkg/tests.py
+++ b/importer/handlers/gpkg/tests.py
@@ -44,10 +44,10 @@ class TestGPKGHandler(TestCase):
     def test_task_list_is_the_expected_one_geojson(self):
         expected = (
             "start_copy",
-            "importer.copy_geonode_resource",
             "importer.copy_dynamic_model",
             "importer.copy_geonode_data_table",
             "importer.publish_resource",
+            "importer.copy_geonode_resource",
         )
         self.assertEqual(len(self.handler.ACTIONS["copy"]), 5)
         self.assertTupleEqual(expected, self.handler.ACTIONS["copy"])
@@ -132,16 +132,15 @@ class TestGPKGHandler(TestCase):
         )
 
         celery_task_handler = SingleMessageErrorHandler()
-        with self.assertRaises(ImportException):
-            """
-            The progress evaluation will raise and exception
-            """
-            celery_task_handler.on_failure(
-                exc=Exception("exception raised"),
-                task_id=started_entry.task_id,
-                args=[str(exec_id), "other_args"],
-                kwargs={},
-                einfo=None,
-            )
+        """
+        The progress evaluation will raise and exception
+        """
+        celery_task_handler.on_failure(
+            exc=Exception("exception raised"),
+            task_id=started_entry.task_id,
+            args=[str(exec_id), "other_args"],
+            kwargs={},
+            einfo=None,
+        )
 
         self.assertEqual("FAILURE", TaskResult.objects.get(task_id=str(exec_id)).status)

--- a/importer/handlers/kml/handler.py
+++ b/importer/handlers/kml/handler.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from geonode.resource.enumerator import ExecutionRequestAction as exa
 from geonode.upload.api.exceptions import UploadParallelismLimitException
@@ -86,6 +87,14 @@ class KMLFileHandler(BaseVectorFileHandler):
                 detail=f"With the provided kml, the number of max parallel upload will exceed the limit of {max_upload}"
             )
 
+        filename = os.path.basename(files.get("base_file"))
+
+        if len(filename.split(".")) > 2:
+            # means that there is a dot other than the one needed for the extension
+            # if we keep it ogr2ogr raise an error, better to remove it
+            raise InvalidKmlException(
+                "Please remove the additional dots in the filename"
+            )
         return True
 
     def get_ogr2ogr_driver(self):

--- a/importer/handlers/kml/handler.py
+++ b/importer/handlers/kml/handler.py
@@ -94,13 +94,13 @@ class KMLFileHandler(BaseVectorFileHandler):
         pass
 
     @staticmethod
-    def create_ogr2ogr_command(files, original_name, override_layer, alternate):
+    def create_ogr2ogr_command(files, original_name, ovverwrite_layer, alternate):
         """
         Define the ogr2ogr command to be executed.
         This is a default command that is needed to import a vector file
         """
 
         base_command = BaseVectorFileHandler.create_ogr2ogr_command(
-            files, original_name, override_layer, alternate
+            files, original_name, ovverwrite_layer, alternate
         )
         return f"{base_command } -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name} --config OGR_SKIP LibKML"

--- a/importer/handlers/kml/tests.py
+++ b/importer/handlers/kml/tests.py
@@ -17,7 +17,7 @@ class TestKMLHandler(TestCase):
         super().setUpClass()
         cls.handler = KMLFileHandler()
         cls.valid_kml = f"{project_dir}/tests/fixture/valid.kml"
-        cls.invalid_kml = f"{project_dir}/tests/fixture/invalid.gpkg"
+        cls.invalid_kml = f"{project_dir}/tests/fixture/inva.lid.kml"
         cls.user, _ = get_user_model().objects.get_or_create(username="admin")
         cls.invalid_files = {"base_file": cls.invalid_kml}
         cls.valid_files = {"base_file": cls.valid_kml}
@@ -39,10 +39,10 @@ class TestKMLHandler(TestCase):
     def test_task_list_is_the_expected_one_geojson(self):
         expected = (
             "start_copy",
-            "importer.copy_geonode_resource",
             "importer.copy_dynamic_model",
             "importer.copy_geonode_data_table",
             "importer.publish_resource",
+            "importer.copy_geonode_resource",
         )
         self.assertEqual(len(self.handler.ACTIONS["copy"]), 5)
         self.assertTupleEqual(expected, self.handler.ACTIONS["copy"])
@@ -52,10 +52,7 @@ class TestKMLHandler(TestCase):
             self.handler.is_valid(files=self.invalid_files, user=self.user)
 
         self.assertIsNotNone(_exc)
-        self.assertTrue(
-            "Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores"
-            in str(_exc.exception.detail)
-        )
+        self.assertTrue("The kml provided is invalid" in str(_exc.exception.detail))
 
     def test_is_valid_should_raise_exception_if_the_parallelism_is_met(self):
         parallelism, _ = UploadParallelismLimit.objects.get_or_create(

--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -68,7 +68,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
 
         additional_params = {
             "skip_existing_layers": _data.pop("skip_existing_layers", "False"),
-            "override_existing_layer": _data.pop("override_existing_layer", "False"),
+            "overwrite_existing_layer": _data.pop("overwrite_existing_layer", "False"),
             "store_spatial_file": _data.pop("store_spatial_files", "True"),
         }
 
@@ -119,12 +119,12 @@ class ShapeFileHandler(BaseVectorFileHandler):
         return ogr.GetDriverByName("ESRI Shapefile")
 
     @staticmethod
-    def create_ogr2ogr_command(files, original_name, override_layer, alternate):
+    def create_ogr2ogr_command(files, original_name, ovverwrite_layer, alternate):
         '''
         Define the ogr2ogr command to be executed.
         This is a default command that is needed to import a vector file
         '''
-        base_command = BaseVectorFileHandler.create_ogr2ogr_command(files, original_name, override_layer, alternate)
+        base_command = BaseVectorFileHandler.create_ogr2ogr_command(files, original_name, ovverwrite_layer, alternate)
         layers = ogr.Open(files.get("base_file"))
         layer = layers.GetLayer(original_name)
         additional_option = " -nlt PROMOTE_TO_MULTI" if layer is not None and 'Point' not in ogr.GeometryTypeToName(layer.GetGeomType()) else " "

--- a/importer/handlers/shapefile/serializer.py
+++ b/importer/handlers/shapefile/serializer.py
@@ -11,7 +11,7 @@ class ShapeFileSerializer(DynamicModelSerializer):
         view_name = "importer_upload"
         fields = (
             "base_file", "dbf_file", "shx_file", "prj_file", "xml_file",
-            "sld_file", "store_spatial_files", "override_existing_layer",
+            "sld_file", "store_spatial_files", "overwrite_existing_layer",
             "skip_existing_layers"
         )
 
@@ -22,5 +22,5 @@ class ShapeFileSerializer(DynamicModelSerializer):
     xml_file = serializers.FileField(required=False)
     sld_file = serializers.FileField(required=False)
     store_spatial_files = serializers.BooleanField(required=False, default=True)
-    override_existing_layer = serializers.BooleanField(required=False, default=False)
+    overwrite_existing_layer = serializers.BooleanField(required=False, default=False)
     skip_existing_layers = serializers.BooleanField(required=False, default=False)

--- a/importer/handlers/shapefile/tests.py
+++ b/importer/handlers/shapefile/tests.py
@@ -49,10 +49,10 @@ class TestShapeFileFileHandler(TestCase):
     def test_copy_task_list_is_the_expected_one(self):
         expected = (
             "start_copy",
-            "importer.copy_geonode_resource",
             "importer.copy_dynamic_model",
             "importer.copy_geonode_data_table",
-            "importer.publish_resource"
+            "importer.publish_resource",
+            "importer.copy_geonode_resource",
         )
         self.assertEqual(len(self.handler.ACTIONS['copy']), 5)
         self.assertTupleEqual(expected, self.handler.ACTIONS['copy'])
@@ -132,5 +132,5 @@ class TestShapeFileFileHandler(TestCase):
 
         _open.assert_called_once()
         _open.assert_called_with(
-            f'/usr/bin/ogr2ogr --config PG_USE_COPY YES -f PostgreSQL PG:" dbname=\'geonode_data\' host=localhost port=5434 user=\'geonode\' password=\'geonode\' " "{self.valid_shp.get("base_file")}" -lco DIM=2 -nln alternate "dataset" -lco GEOMETRY_NAME=geometry ', stdout=-1, stderr=-1, shell=True # noqa
+            f'/usr/bin/ogr2ogr --config PG_USE_COPY YES -f PostgreSQL PG:" dbname=\'geonode_data\' host=localhost port=5434 user=\'geonode\' password=\'geonode\' " "{self.valid_shp.get("base_file")}" -lco DIM=2 -nln alternate "dataset" -lco precision=no -lco GEOMETRY_NAME=geometry ', stdout=-1, stderr=-1, shell=True # noqa
         )

--- a/importer/handlers/shapefile/tests.py
+++ b/importer/handlers/shapefile/tests.py
@@ -122,7 +122,7 @@ class TestShapeFileFileHandler(TestCase):
             files=self.valid_shp,
             original_name="dataset",
             handler_module_path=str(self.handler),
-            override_layer=False,
+            ovverwrite_layer=False,
             alternate="alternate"
         )
 

--- a/importer/handlers/utils.py
+++ b/importer/handlers/utils.py
@@ -42,9 +42,9 @@ def should_be_imported(layer: str, user: get_user_model(), **kwargs) -> bool:
     If layer_name + user (without the addition of any execution id)
     already exists, will apply one of the rule available:
     - skip_existing_layer: means that if already exists will be skept
-    - override_layer: means that if already exists will be overridden
+    - ovverwrite_layer: means that if already exists will be overridden
         - the dynamic model should be recreated
-        - ogr2ogr should override the layer
+        - ogr2ogr should overwrite the layer
         - the publisher should republish the resource
         - geonode should update it
     """

--- a/importer/orchestrator.py
+++ b/importer/orchestrator.py
@@ -338,7 +338,7 @@ class ImportOrchestrator:
     def _last_step(self, execution_id, handler_module_path):
         '''
         Last hookable step for each handler before mark the execution as completed
-        To override this, please hook the method perform_last_step from the Handler
+        To overwrite this, please hook the method perform_last_step from the Handler
         '''
         if not handler_module_path:
             return

--- a/importer/orchestrator.py
+++ b/importer/orchestrator.py
@@ -276,6 +276,7 @@ class ImportOrchestrator:
         legacy_upload_name="",
         action=None,
         name=None,
+        source=None
     ) -> UUID:
         """
         Create an execution request for the user. Return the UUID of the request
@@ -288,6 +289,7 @@ class ImportOrchestrator:
             input_params=input_params,
             action=action,
             name=name,
+            source=source
         )
         if self.enable_legacy_upload_status:
             # getting the package name from the base_filename

--- a/importer/publisher.py
+++ b/importer/publisher.py
@@ -51,7 +51,7 @@ class DataPublisher:
         self.get_or_create_store()
         _res = self.cat.get_resource(resource_name, store=self.store, workspace=self.workspace)
         return True if _res else False
-    
+
     def publish_resources(self, resources: List[str]):
         """
         Given a list of strings (which rappresent the table on geoserver)
@@ -64,7 +64,7 @@ class DataPublisher:
             store=self.store,
             workspace=self.workspace,
         )
-    
+
     def overwrite_resources(self, resources: List[str]):
         '''
         Not available for now, waiting geoserver 2.20/2.21 available with Geonode

--- a/importer/publisher.py
+++ b/importer/publisher.py
@@ -47,6 +47,11 @@ class DataPublisher:
             files, action, layer_name, alternate, **kwargs
         )
 
+    def get_resource(self, resource_name) -> bool:
+        self.get_or_create_store()
+        _res = self.cat.get_resource(resource_name, store=self.store, workspace=self.workspace)
+        return True if _res else False
+    
     def publish_resources(self, resources: List[str]):
         """
         Given a list of strings (which rappresent the table on geoserver)

--- a/importer/publisher.py
+++ b/importer/publisher.py
@@ -59,6 +59,12 @@ class DataPublisher:
             store=self.store,
             workspace=self.workspace,
         )
+    
+    def overwrite_resources(self, resources: List[str]):
+        '''
+        Not available for now, waiting geoserver 2.20/2.21 available with Geonode
+        '''
+        pass
 
     def get_or_create_store(self):
         """

--- a/importer/tests/end2end/test_end2end.py
+++ b/importer/tests/end2end/test_end2end.py
@@ -14,6 +14,7 @@ from geonode.utils import OGC_Servers_Handler
 from geoserver.catalog import Catalog
 from importer import project_dir
 from importer.tests.utils import ImporterBaseTestSupport
+from geonode.geoserver.signals import geoserver_delete
 import gisdata
 geourl = settings.GEODATABASE_URL
 
@@ -91,35 +92,47 @@ class ImporterGeoPackageImportTest(BaseImporterEndToEndTest):
     @mock.patch.dict(os.environ, {"GEONODE_GEODATABASE": "test_geonode_data"})
     @override_settings(GEODATABASE_URL=f"{geourl.split('/geonode_data')[0]}/test_geonode_data")
     def test_import_geopackage(self):
+        layer = self.cat.get_layer("geonode:stazioni_metropolitana")
+        self.cat.delete(layer)
         payload = {
             "base_file": open(self.valid_gkpg, 'rb'),
         }
         initial_name = "stazioni_metropolitana"
         self._assertimport(payload, initial_name)
-
+        layer = self.cat.get_layer("geonode:stazioni_metropolitana")
+        self.cat.delete(layer)
 
 class ImporterGeoJsonImportTest(BaseImporterEndToEndTest):
 
     @mock.patch.dict(os.environ, {"GEONODE_GEODATABASE": "test_geonode_data"})
     @override_settings(GEODATABASE_URL=f"{geourl.split('/geonode_data')[0]}/test_geonode_data")
     def test_import_geojson(self):
+        layer = self.cat.get_layer("geonode:valid")
+        self.cat.delete(layer)
+
         payload = {
             "base_file": open(self.valid_geojson, 'rb'),
         }
         initial_name = "valid"
         self._assertimport(payload, initial_name)
+        layer = self.cat.get_layer("geonode:valid")
+        self.cat.delete(layer)
 
 
 class ImporterKMLImportTest(BaseImporterEndToEndTest):
 
     @mock.patch.dict(os.environ, {"GEONODE_GEODATABASE": "test_geonode_data"})
     @override_settings(GEODATABASE_URL=f"{geourl.split('/geonode_data')[0]}/test_geonode_data")
-    def test_import_shapefile(self):
+    def test_import_kml(self):
+        layer = self.cat.get_layer("geonode:extruded_polygon")
+        self.cat.delete(layer)
         payload = {
             "base_file": open(self.valid_kml, 'rb'),
         }
         initial_name = "extruded_polygon"
         self._assertimport(payload, initial_name)
+        layer = self.cat.get_layer("geonode:extruded_polygon")
+        self.cat.delete(layer)
 
 
 class ImporterShapefileImportTest(BaseImporterEndToEndTest):
@@ -127,6 +140,10 @@ class ImporterShapefileImportTest(BaseImporterEndToEndTest):
     @mock.patch.dict(os.environ, {"GEONODE_GEODATABASE": "test_geonode_data"})
     @override_settings(GEODATABASE_URL=f"{geourl.split('/geonode_data')[0]}/test_geonode_data")
     def test_import_shapefile(self):
+        layer = self.cat.get_layer("geonode:san_andres_y_providencia_highway")
+        self.cat.delete(layer)
         payload = {_filename: open(_file, 'rb') for _filename, _file in self.valid_shp.items()}
         initial_name = "san_andres_y_providencia_highway"
         self._assertimport(payload, initial_name)
+        layer = self.cat.get_layer("geonode:san_andres_y_providencia_highway")
+        self.cat.delete(layer)

--- a/importer/tests/unit/test_models.py
+++ b/importer/tests/unit/test_models.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from dynamic_models.models import ModelSchema, FieldSchema
 from geonode.base.populate_test_data import create_single_dataset
+from importer.models import ResourceHandlerInfo
 
 
 class TestModelSchemaSignal(TestCase):
@@ -8,6 +9,7 @@ class TestModelSchemaSignal(TestCase):
 
     def setUp(self):
         self.resource = create_single_dataset(name="test_dataset")
+        ResourceHandlerInfo.objects.create(resource=self.resource, handler_module_path="importer.handlers.shapefile.handler.ShapeFileHandler")
         self.dynamic_model = ModelSchema.objects.create(
             name=self.resource.name, db_name="datastore"
         )

--- a/importer/tests/unit/test_orchestrator.py
+++ b/importer/tests/unit/test_orchestrator.py
@@ -321,13 +321,8 @@ class TestsImporterOrchestrator(GeoNodeBaseTestSupport):
             success_entry = TaskResult.objects.create(
                 task_id="task_id_success", status="SUCCESS", task_args=exec_id
             )
-            with self.assertRaises(ImportException) as e:
-                self.orchestrator.evaluate_execution_progress(exec_id)
+            self.orchestrator.evaluate_execution_progress(exec_id)
 
-            self.assertEqual(
-                f"For the execution ID {exec_id} The following celery task are failed: ['task_id_FAILED']",
-                str(e.exception)
-            )
 
         finally:
             if FAILED_entry:

--- a/importer/tests/unit/test_task.py
+++ b/importer/tests/unit/test_task.py
@@ -38,7 +38,7 @@ class TestCeleryTasks(ImporterBaseTestSupport):
             legacy_upload_name="dummy",
             input_params={
                 "files": {"base_file": "/filepath"},
-                # "override_existing_layer": True,
+                # "overwrite_existing_layer": True,
                 "store_spatial_files": True,
             },
         )
@@ -175,7 +175,7 @@ class TestCeleryTasks(ImporterBaseTestSupport):
                 legacy_upload_name="dummy",
                 input_params={
                     "files": {"base_file": "/filepath"},
-                    "override_existing_layer": True,
+                    "overwrite_existing_layer": True,
                     "store_spatial_files": True,
                 },
             )
@@ -287,7 +287,7 @@ class TestDynamicModelSchema(SimpleTestCase):
             legacy_upload_name="dummy",
             input_params={
                 "files": {"base_file": "/filepath"},
-                # "override_existing_layer": True,
+                # "overwrite_existing_layer": True,
                 "store_spatial_files": True,
             },
         )

--- a/importer/utils.py
+++ b/importer/utils.py
@@ -11,7 +11,7 @@ class ImporterConcreteManager(GeoServerResourceManager):
     """
     The default GeoNode concrete manager, handle the communication with geoserver
     For this implementation the interaction with geoserver is not needed
-    so we are going to override the concrete manager to avoid it
+    so we are going to overwrite the concrete manager to avoid it
     """
 
     def copy(self, instance, uuid, defaults):


### PR DESCRIPTION
- Rename `override` into `overwrite`
- Add overwrite method for raster and vector layers
- overwrite published resources, for now, is skip since we are waiting for geoserver 2.20/2.21
- test fixup test
- source added