### PR TITLE
[Fixes #77] Create CSV handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here a description of the various codes:
 ### CSV
 
 
-The CSV colum for lat/long are the followings:
+The CSV colum accepted for lat/long CSVs are the followings:
 
 - `lat`, `latitude`, `y`
 - `long`, `longitude`, `x`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The implemented file type handlers so far are:
 - GeoJSON - Vector
 - Shapefiles - Vector
 - KML - Vector
+- CSV - Vector
 - GeoTiff - Raster
 
 
@@ -74,6 +75,7 @@ IMPORTER_HANDLERS = os.getenv('IMPORTER_HANDLERS', [
     'importer.handlers.geojson.handler.GeoJsonFileHandler',
     'importer.handlers.shapefile.handler.ShapeFileHandler',
     'importer.handlers.kml.handler.KMLFileHandler',
+    'importer.handlers.csv.handler.CSVFileHandler',
     'importer.handlers.geotiff.handler.GeoTiffFileHandler'
 ])
 

--- a/README.md
+++ b/README.md
@@ -141,3 +141,18 @@ Here a description of the various codes:
 ### GeoJson
 
 - Filename should not contain dots, for example "invalid.file.name.geojson" -> "valid_file_name.geojson"
+
+
+### CSV
+
+
+The CSV colum for lat/long are the followings:
+
+- `lat`, `latitude`, `y`
+- `long`, `longitude`, `x`
+
+NB: The CSV with the above, are treated as `POINTS`
+
+Otherwise if you have to pass a geometry column, the accepted column names are:
+
+- `geom`, `geometry`, `the_geom`, `wkt_geom`

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -256,7 +256,7 @@ class BaseVectorFileHandler(BaseHandler):
         Internally will call the steps required to import the
         data inside the geonode_data database
         """
-        layers = self.get_ogr2ogr_driver().Open(files.get("base_file"))
+        layers = self.get_ogr2ogr_driver().Open(files.get("base_file"), 0)
         # for the moment we skip the dyanamic model creation
         layer_count = len(layers)
         logger.info(f"Total number of layers available: {layer_count}")
@@ -415,7 +415,6 @@ class BaseVectorFileHandler(BaseHandler):
             for x in layer.schema
         ]
         if layer.GetGeometryColumn() or self.default_geometry_column_name and ogr.GeometryTypeToName(layer.GetGeomType()) not in ['Geometry Collection', 'Unknown (any)']:
-            # the geometry colum is not returned rom the layer.schema, so we need to extract it manually
             layer_schema += [
                 {
                     "name": layer.GetGeometryColumn() or self.default_geometry_column_name,

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -256,7 +256,7 @@ class BaseVectorFileHandler(BaseHandler):
         Internally will call the steps required to import the
         data inside the geonode_data database
         """
-        layers = self.get_ogr2ogr_driver().Open(files.get("base_file"), 0)
+        layers = self.get_ogr2ogr_driver().Open(files.get("base_file"))
         # for the moment we skip the dyanamic model creation
         layer_count = len(layers)
         logger.info(f"Total number of layers available: {layer_count}")
@@ -415,6 +415,7 @@ class BaseVectorFileHandler(BaseHandler):
             for x in layer.schema
         ]
         if layer.GetGeometryColumn() or self.default_geometry_column_name and ogr.GeometryTypeToName(layer.GetGeomType()) not in ['Geometry Collection', 'Unknown (any)']:
+            # the geometry colum is not returned rom the layer.schema, so we need to extract it manually
             layer_schema += [
                 {
                     "name": layer.GetGeometryColumn() or self.default_geometry_column_name,

--- a/importer/handlers/csv/exceptions.py
+++ b/importer/handlers/csv/exceptions.py
@@ -1,0 +1,9 @@
+from rest_framework.exceptions import APIException
+from rest_framework import status
+
+
+class InvalidCSVException(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "The csv provided is invalid"
+    default_code = "invalid_csv"
+    category = "importer"

--- a/importer/handlers/csv/handler.py
+++ b/importer/handlers/csv/handler.py
@@ -97,7 +97,7 @@ class CSVFileHandler(BaseVectorFileHandler):
         This is a default command that is needed to import a vector file
         '''
         base_command = BaseVectorFileHandler.create_ogr2ogr_command(files, original_name, ovverwrite_layer, alternate)
-        additional_option = ' -oo "GEOM_POSSIBLE_NAMES=geom*,the_geom*" -oo "X_POSSIBLE_NAMES=x,long*" -oo "Y_POSSIBLE_NAMES=y,lat*"'
+        additional_option = ' -oo "GEOM_POSSIBLE_NAMES=geom*,the_geom*,wkt_geom" -oo "X_POSSIBLE_NAMES=x,long*" -oo "Y_POSSIBLE_NAMES=y,lat*"'
         return f"{base_command } -oo KEEP_GEOM_COLUMNS=NO -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name} " + additional_option
 
     def create_dynamic_model_fields(

--- a/importer/handlers/csv/handler.py
+++ b/importer/handlers/csv/handler.py
@@ -52,9 +52,9 @@ class CSVFileHandler(BaseVectorFileHandler):
         if not base:
             return False
         return (
-            base.endswith(".csv")
+            base.lower().endswith(".csv")
             if isinstance(base, str)
-            else base.name.endswith(".csv")
+            else base.name.lower().endswith(".csv")
         )
 
     @staticmethod
@@ -165,7 +165,7 @@ class CSVFileHandler(BaseVectorFileHandler):
             return [
                 {
                     "name": alternate,
-                    "crs": ResourceBase.objects.filter(Q(alternate__icontains=layer_name) | Q(title__icontains=layer_name))
+                    "crs": ResourceBase.objects.filter(alternate__istartswith=layer_name)
                     .first()
                     .srid,
                 }

--- a/importer/handlers/csv/handler.py
+++ b/importer/handlers/csv/handler.py
@@ -1,0 +1,184 @@
+import logging
+
+from geonode.resource.enumerator import ExecutionRequestAction as exa
+from geonode.upload.api.exceptions import UploadParallelismLimitException
+from geonode.upload.utils import UploadLimitValidator
+from importer.celery_tasks import create_dynamic_structure
+from importer.handlers.csv.exceptions import InvalidCSVException
+from osgeo import ogr
+from celery import group
+from geonode.base.models import ResourceBase
+from dynamic_models.models import ModelSchema
+from importer.handlers.common.vector import BaseVectorFileHandler
+from importer.handlers.utils import GEOM_TYPE_MAPPING
+from django.db.models import Q
+
+logger = logging.getLogger(__name__)
+
+
+class CSVFileHandler(BaseVectorFileHandler):
+    """
+    Handler to import CSV files into GeoNode data db
+    It must provide the task_lists required to comple the upload
+    """
+
+    ACTIONS = {
+        exa.IMPORT.value: (
+            "start_import",
+            "importer.import_resource",
+            "importer.publish_resource",
+            "importer.create_geonode_resource",
+        ),
+        exa.COPY.value: (
+            "start_copy",
+            "importer.copy_dynamic_model",
+            "importer.copy_geonode_data_table",
+            "importer.publish_resource",
+            "importer.copy_geonode_resource",
+        ),
+    }
+
+    @property
+    def supported_file_extension_config(self):
+        return {"id": "csv", "label": "CSV", "format": "archive", "ext": ["csv"]}
+
+    @staticmethod
+    def can_handle(_data) -> bool:
+        """
+        This endpoint will return True or False if with the info provided
+        the handler is able to handle the file or not
+        """
+        base = _data.get("base_file")
+        if not base:
+            return False
+        return (
+            base.endswith(".csv")
+            if isinstance(base, str)
+            else base.name.endswith(".csv")
+        )
+
+    @staticmethod
+    def is_valid(files, user):
+        BaseVectorFileHandler.is_valid(files, user)
+        # getting the upload limit validation
+        upload_validator = UploadLimitValidator(user)
+        upload_validator.validate_parallelism_limit_per_user()
+        actual_upload = upload_validator._get_parallel_uploads_count()
+        max_upload = upload_validator._get_max_parallel_uploads()
+
+        layers = CSVFileHandler().get_ogr2ogr_driver().Open(files.get("base_file"))
+
+        if not layers:
+            raise InvalidCSVException("The CSV provided is invalid, no layers found")
+
+        layers_count = len(layers)
+
+        if layers_count >= max_upload:
+            raise UploadParallelismLimitException(
+                detail=f"The number of layers in the CSV {layers_count} is greater than "
+                f"the max parallel upload permitted: {max_upload} "
+                f"please upload a smaller file"
+            )
+        elif layers_count + actual_upload >= max_upload:
+            raise UploadParallelismLimitException(
+                detail=f"With the provided CSV, the number of max parallel upload will exceed the limit of {max_upload}"
+            )
+
+        return True
+
+    def get_ogr2ogr_driver(self):
+        return ogr.GetDriverByName("CSV")
+
+
+    @staticmethod
+    def create_ogr2ogr_command(files, original_name, ovverwrite_layer, alternate):
+        '''
+        Define the ogr2ogr command to be executed.
+        This is a default command that is needed to import a vector file
+        '''
+        base_command = BaseVectorFileHandler.create_ogr2ogr_command(files, original_name, ovverwrite_layer, alternate)
+        additional_option = ' -oo "GEOM_POSSIBLE_NAMES=geom*,the_geom*" -oo "X_POSSIBLE_NAMES=x,long*" -oo "Y_POSSIBLE_NAMES=y,lat*"'
+        return f"{base_command } -oo KEEP_GEOM_COLUMNS=NO -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name} " + additional_option
+
+    def create_dynamic_model_fields(
+        self,
+        layer: str,
+        dynamic_model_schema: ModelSchema,
+        overwrite: bool,
+        execution_id: str,
+        layer_name: str,
+    ):
+        # retrieving the field schema from ogr2ogr and converting the type to Django Types
+        layer_schema = [
+            {"name": x.name.lower(), "class_name": self._get_type(x), "null": True}
+            for x in layer.schema
+        ]
+        if layer.GetGeometryColumn() or self.default_geometry_column_name and ogr.GeometryTypeToName(layer.GetGeomType()) not in ['Geometry Collection', 'Unknown (any)']:
+            # the geometry colum is not returned rom the layer.schema, so we need to extract it manually
+            # checking if the geometry has been wrogly read as string
+            possible_geometry_column_name = ['geom', 'geometry', 'wkt_geom', 'the_geom']
+            possible_latlong_column = ['latitude', 'longitude', 'lat', 'long', 'x', 'y']
+            schema_keys = [x['name'] for x in layer_schema]
+            geom_is_in_schema = (x in schema_keys for x in possible_geometry_column_name)
+            if any(geom_is_in_schema) and layer.GetGeomType() == 100:  # 100 means None so Geometry not found
+                field_name = [x for x in possible_geometry_column_name if x in schema_keys][0]
+                index = layer.GetFeature(1).keys().index(field_name)
+                geom = [x for x in layer.GetFeature(1)][index]
+                class_name = GEOM_TYPE_MAPPING.get(
+                    self.promote_to_multi(
+                        geom.split("(")[0].replace(" ", "").title()
+                    )
+                )
+                layer_schema = [x for x in layer_schema if field_name not in x['name']]
+            elif any(x in possible_latlong_column for x in schema_keys):
+                class_name = GEOM_TYPE_MAPPING.get(self.promote_to_multi('Point'))
+            else:
+                class_name = GEOM_TYPE_MAPPING.get(self.promote_to_multi(ogr.GeometryTypeToName(layer.GetGeomType())))
+
+            layer_schema += [
+                {
+                    "name": layer.GetGeometryColumn() or self.default_geometry_column_name,
+                    "class_name": class_name,
+                    "dim": 2 if not ogr.GeometryTypeToName(layer.GetGeomType()).lower().startswith('3d') else 3
+                }
+            ]
+
+        # ones we have the schema, here we create a list of chunked value
+        # so the async task will handle max of 30 field per task
+        list_chunked = [
+            layer_schema[i: i + 30] for i in range(0, len(layer_schema), 30)
+        ]
+
+        # definition of the celery group needed to run the async workflow.
+        # in this way each task of the group will handle only 30 field
+        celery_group = group(
+            create_dynamic_structure.s(
+                execution_id, schema, dynamic_model_schema.id, overwrite, layer_name
+            )
+            for schema in list_chunked
+        )
+
+        return dynamic_model_schema, celery_group
+
+    def extract_resource_to_publish(self, files, action, layer_name, alternate, **kwargs):
+        if action == exa.COPY.value:
+            return [
+                {
+                    "name": alternate,
+                    "crs": ResourceBase.objects.filter(Q(alternate__icontains=layer_name) | Q(title__icontains=layer_name))
+                    .first()
+                    .srid,
+                }
+            ]
+
+        layers = self.get_ogr2ogr_driver().Open(files.get("base_file"), 0)
+        if not layers:
+            return []
+        return [
+            {
+                "name": alternate or layer_name,
+                "crs": self.identify_authority(_l) if _l.GetSpatialRef() else 'EPSG:4326'
+            }
+            for _l in layers
+            if self.fixup_name(_l.GetName()) == layer_name
+        ]

--- a/importer/handlers/csv/handler.py
+++ b/importer/handlers/csv/handler.py
@@ -40,7 +40,7 @@ class CSVFileHandler(BaseVectorFileHandler):
 
     @property
     def supported_file_extension_config(self):
-        return {"id": "csv", "label": "CSV", "format": "archive", "ext": ["csv"]}
+        return {"id": "csv", "label": "CSV", "format": "vector", "mimeType": ["text/csv"], "ext": ["csv"], "optional": ["sld", "xml"]}
 
     @staticmethod
     def can_handle(_data) -> bool:

--- a/importer/handlers/csv/tests.py
+++ b/importer/handlers/csv/tests.py
@@ -1,0 +1,140 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from geonode.base.populate_test_data import create_single_dataset
+from geonode.upload.api.exceptions import UploadParallelismLimitException
+from geonode.upload.models import UploadParallelismLimit
+from importer import project_dir
+from importer.handlers.common.vector import import_with_ogr2ogr
+from importer.handlers.csv.exceptions import InvalidCSVException
+from importer.handlers.csv.handler import CSVFileHandler
+from osgeo import ogr
+
+
+class TestCSVHandler(TestCase):
+    databases = ("default", "datastore")
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.handler = CSVFileHandler()
+        cls.valid_csv = f"{project_dir}/tests/fixture/valid.csv"
+        cls.invalid_csv = f"{project_dir}/tests/fixture/invalid.csv"
+        cls.user, _ = get_user_model().objects.get_or_create(username="admin")
+        cls.invalid_files = {"base_file": cls.invalid_csv}
+        cls.valid_files = {"base_file": cls.valid_csv}
+        cls.owner = get_user_model().objects.first()
+        cls.layer = create_single_dataset(
+            name="test", owner=cls.owner
+        )
+
+    def test_task_list_is_the_expected_one(self):
+        expected = (
+            "start_import",
+            "importer.import_resource",
+            "importer.publish_resource",
+            "importer.create_geonode_resource",
+        )
+        self.assertEqual(len(self.handler.ACTIONS["import"]), 4)
+        self.assertTupleEqual(expected, self.handler.ACTIONS["import"])
+
+    def test_task_list_is_the_expected_one_geojson(self):
+        expected = (
+            "start_copy",
+            "importer.copy_dynamic_model",
+            "importer.copy_geonode_data_table",
+            "importer.publish_resource",
+            "importer.copy_geonode_resource",
+        )
+        self.assertEqual(len(self.handler.ACTIONS["copy"]), 5)
+        self.assertTupleEqual(expected, self.handler.ACTIONS["copy"])
+
+    def test_is_valid_should_raise_exception_if_the_csv_is_invalid(self):
+        with self.assertRaises(InvalidCSVException) as _exc:
+            self.handler.is_valid(files=self.invalid_files, user=self.user)
+
+        self.assertIsNotNone(_exc)
+        self.assertTrue(
+            "The CSV provided is invalid, no layers found"
+            in str(_exc.exception.detail)
+        )
+
+    def test_is_valid_should_raise_exception_if_the_parallelism_is_met(self):
+        parallelism, created = UploadParallelismLimit.objects.get_or_create(
+            slug="default_max_parallel_uploads"
+        )
+        old_value = parallelism.max_number
+        try:
+            UploadParallelismLimit.objects.filter(
+                slug="default_max_parallel_uploads"
+            ).update(max_number=0)
+
+            with self.assertRaises(UploadParallelismLimitException):
+                self.handler.is_valid(files=self.valid_files, user=self.user)
+
+        finally:
+            parallelism.max_number = old_value
+            parallelism.save()
+
+    def test_is_valid_should_raise_exception_if_layer_are_greater_than_max_parallel_upload(
+        self,
+    ):
+        parallelism, created = UploadParallelismLimit.objects.get_or_create(
+            slug="default_max_parallel_uploads"
+        )
+        old_value = parallelism.max_number
+        try:
+            UploadParallelismLimit.objects.filter(
+                slug="default_max_parallel_uploads"
+            ).update(max_number=1)
+
+            with self.assertRaises(UploadParallelismLimitException):
+                self.handler.is_valid(files=self.valid_files, user=self.user)
+
+        finally:
+            parallelism.max_number = old_value
+            parallelism.save()
+
+    def test_is_valid_should_pass_with_valid_csv(self):
+        self.handler.is_valid(files=self.valid_files, user=self.user)
+
+    def test_get_ogr2ogr_driver_should_return_the_expected_driver(self):
+        expected = ogr.GetDriverByName("CSV")
+        actual = self.handler.get_ogr2ogr_driver()
+        self.assertEqual(type(expected), type(actual))
+
+    def test_can_handle_should_return_true_for_geopackage(self):
+        actual = self.handler.can_handle(self.valid_files)
+        self.assertTrue(actual)
+
+    def test_can_handle_should_return_false_for_other_files(self):
+        actual = self.handler.can_handle({"base_file": "random.file"})
+        self.assertFalse(actual)
+
+    @patch('importer.handlers.common.vector.Popen')
+    def test_import_with_ogr2ogr_without_errors_should_call_the_right_command(self, _open):
+        _uuid = uuid.uuid4()
+
+        comm = MagicMock()
+        comm.communicate.return_value = b"", b""
+        _open.return_value = comm
+
+        _task, alternate, execution_id = import_with_ogr2ogr(
+            execution_id=str(_uuid),
+            files=self.valid_files,
+            original_name="dataset",
+            handler_module_path=str(self.handler),
+            ovverwrite_layer=False,
+            alternate="alternate"
+        )
+
+        self.assertEqual('ogr2ogr', _task)
+        self.assertEqual(alternate, "alternate")
+        self.assertEqual(str(_uuid), execution_id)
+
+        _open.assert_called_once()
+        _open.assert_called_with(
+            f'/usr/bin/ogr2ogr --config PG_USE_COPY YES -f PostgreSQL PG:" dbname=\'geonode_data\' host=localhost port=5434 user=\'geonode\' password=\'geonode\' " "{self.valid_csv}" -lco DIM=2 -nln alternate "dataset" -oo KEEP_GEOM_COLUMNS=NO -lco GEOMETRY_NAME=geometry  -oo "GEOM_POSSIBLE_NAMES=geom*,the_geom*" -oo "X_POSSIBLE_NAMES=x,long*" -oo "Y_POSSIBLE_NAMES=y,lat*"', stdout=-1, stderr=-1, shell=True # noqa
+        )

--- a/importer/handlers/utils.py
+++ b/importer/handlers/utils.py
@@ -23,16 +23,20 @@ STANDARD_TYPE_MAPPING = {
 
 GEOM_TYPE_MAPPING = {
     "Line String": "django.contrib.gis.db.models.fields.LineStringField",
+    "Linestring": "django.contrib.gis.db.models.fields.LineStringField",
     "3D Line String": "django.contrib.gis.db.models.fields.LineStringField",
     "Multi Line String": "django.contrib.gis.db.models.fields.MultiLineStringField",
+    "Multilinestring": "django.contrib.gis.db.models.fields.MultiLineStringField",
     "3D Multi Line String": "django.contrib.gis.db.models.fields.MultiLineStringField",
     "Point": "django.contrib.gis.db.models.fields.PointField",
     "3D Point": "django.contrib.gis.db.models.fields.PointField",
     "Multi Point": "django.contrib.gis.db.models.fields.MultiPointField",
+    "Multipoint": "django.contrib.gis.db.models.fields.MultiPointField",
     "Polygon": "django.contrib.gis.db.models.fields.PolygonField",
     "3D Polygon": "django.contrib.gis.db.models.fields.PolygonField",
     "3D Multi Point": "django.contrib.gis.db.models.fields.MultiPointField",
     "Multi Polygon": "django.contrib.gis.db.models.fields.MultiPolygonField",
+    "Multipolygon": "django.contrib.gis.db.models.fields.MultiPolygonField",
     "3D Multi Polygon": "django.contrib.gis.db.models.fields.MultiPolygonField",
 }
 

--- a/importer/tests/fixture/valid.csv
+++ b/importer/tests/fixture/valid.csv
@@ -1,0 +1,4 @@
+id;name;amount;city;geom
+1;Kevin;2.1;Rapperswil;POINT(8.8249 47.2274)
+2;Eva;2.2;Zürich;POINT(8.5435 47.3768)
+3;"Jimmy;Muff";2.3;;POINT(7.4397 46.9487)


### PR DESCRIPTION
Ref #77 

- base csv handler
- handle CSV with geometry or lat-long columns
- the geometry name is guessed via ogr2ogr
- the `create_dynamic_model_fields` function overrides the default one because sometimes ogr2ogr is not able to parse the geometry correctly
- test coverage

The CSV column accepted for lat/long CSVs are the followings:

- `lat`, `latitude`, `y`
- `long`, `longitude`, `x`

NB: The CSV with the above, are treated as `POINTS`

Otherwise, if you have to pass a geometry column, the accepted column names are:

- `geom`, `geometry`, `the_geom`, `wkt_geom`
