### PR TITLE
Allow nonspatial layer import

### DIFF
--- a/importer/celery_tasks.py
+++ b/importer/celery_tasks.py
@@ -143,6 +143,7 @@ def import_resource(self, execution_id, /, handler_module_path, action, **kwargs
         if not _datastore.input_is_valid():
             raise Exception("dataset is invalid")
 
+        _datastore.prepare_import(**kwargs)
         _datastore.start_import(execution_id, **kwargs)
 
         """

--- a/importer/datastore.py
+++ b/importer/datastore.py
@@ -26,8 +26,15 @@ class DataStoreManager:
         """
         return self.handler.is_valid(self.files, self.user)
 
+    def prepare_import(self, **kwargs):
+        """
+        prepares the data before the actual import
+        """
+        return self.handler().prepare_import(self.files, self.execution_id, **kwargs)
+
     def start_import(self, execution_id, **kwargs):
         """
         call the resource handler object to perform the import phase
         """
         return self.handler().import_resource(self.files, execution_id,  **kwargs)
+    

--- a/importer/handlers/base.py
+++ b/importer/handlers/base.py
@@ -120,6 +120,13 @@ class BaseHandler(ABC):
         """
         return f"Task: {task_name} raised an error during actions for layer: {args[-1]}: {exc}"
 
+    def prepare_import(self, files, execution_id, **kwargs):
+        """
+        Optional preparation step to before the actual import begins.
+        By default this does nothing.
+        """
+        pass
+
     def import_resource(self, files: dict, execution_id: str, **kwargs):
         """
         Define the step to perform the import of the data

--- a/importer/handlers/common/vector.py
+++ b/importer/handlers/common/vector.py
@@ -151,7 +151,7 @@ class BaseVectorFileHandler(BaseHandler):
             % (db_name, db_host, db_port, db_user, db_password)
         )
         options += f'"{files.get("base_file")}"' + " "
-        options += "-lco DIM=2 "
+#        options += "-lco DIM=2 "
         options += f'-nln {alternate} "{original_name}"'
 
         if ovverwrite_layer:
@@ -281,7 +281,7 @@ class BaseVectorFileHandler(BaseHandler):
                         ),
                         overwrite_existing_layer=should_be_overwritten,
                     )
-                    and layer.GetGeometryColumn() is not None
+                    #and layer.GetGeometryColumn() is not None
                 ):
                     # update the execution request object
                     # setup dynamic model and retrieve the group task needed for tun the async workflow
@@ -414,7 +414,7 @@ class BaseVectorFileHandler(BaseHandler):
             {"name": x.name.lower(), "class_name": self._get_type(x), "null": True}
             for x in layer.schema
         ]
-        if layer.GetGeometryColumn() or self.default_geometry_column_name and ogr.GeometryTypeToName(layer.GetGeomType()) not in ['Geometry Collection', 'Unknown (any)']:
+        if layer.GetGeometryColumn() or self.default_geometry_column_name and ogr.GeometryTypeToName(layer.GetGeomType()) not in ['Geometry Collection', 'Unknown (any)', 'None']:
             # the geometry colum is not returned rom the layer.schema, so we need to extract it manually
             layer_schema += [
                 {

--- a/importer/handlers/geojson/handler.py
+++ b/importer/handlers/geojson/handler.py
@@ -100,4 +100,4 @@ class GeoJsonFileHandler(BaseVectorFileHandler):
         base_command = BaseVectorFileHandler.create_ogr2ogr_command(
             files, original_name, ovverwrite_layer, alternate
         )
-        return f"{base_command } -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name}"
+        return f"{base_command } -lco DIM=2 -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name}"

--- a/importer/handlers/kml/handler.py
+++ b/importer/handlers/kml/handler.py
@@ -116,4 +116,4 @@ class KMLFileHandler(BaseVectorFileHandler):
         base_command = BaseVectorFileHandler.create_ogr2ogr_command(
             files, original_name, ovverwrite_layer, alternate
         )
-        return f"{base_command } -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name} --config OGR_SKIP LibKML"
+        return f"{base_command } -lco DIM=2 -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name} --config OGR_SKIP LibKML"

--- a/importer/handlers/shapefile/handler.py
+++ b/importer/handlers/shapefile/handler.py
@@ -139,7 +139,7 @@ class ShapeFileHandler(BaseVectorFileHandler):
         layers = ogr.Open(files.get("base_file"))
         layer = layers.GetLayer(original_name)
         additional_option = " -nlt PROMOTE_TO_MULTI" if layer is not None and 'Point' not in ogr.GeometryTypeToName(layer.GetGeomType()) else " "
-        return f"{base_command } -lco precision=no -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name}" + additional_option
+        return f"{base_command } -lco precision=no -lco DIM=2 -lco GEOMETRY_NAME={BaseVectorFileHandler().default_geometry_column_name}" + additional_option
 
     def promote_to_multi(self, geometry_name):
         '''

--- a/importer/tests/unit/test_task.py
+++ b/importer/tests/unit/test_task.py
@@ -91,9 +91,11 @@ class TestCeleryTasks(ImporterBaseTestSupport):
 
     @patch("importer.celery_tasks.orchestrator.perform_next_step")
     @patch("importer.celery_tasks.DataStoreManager.input_is_valid")
+    @patch("importer.celery_tasks.DataStoreManager.prepare_import")
     @patch("importer.celery_tasks.DataStoreManager.start_import")
     def test_import_resource_should_work(
         self,
+        prepare_import,
         start_import,
         is_valid,
         importer,
@@ -116,6 +118,7 @@ class TestCeleryTasks(ImporterBaseTestSupport):
             handler_module_path="importer.handlers.gpkg.handler.GPKGFileHandler",
         )
 
+        prepare_import.assert_called_once()
         start_import.assert_called_once()
         ExecutionRequest.objects.filter(exec_id=str(exec_id)).delete()
 


### PR DESCRIPTION
This commit includes minor changes to the importer to allow layers without geometry information. This includes two things: First, we relax the assumption that a geometry column must be present and let the actual handler implementation decide to add the dimension `lco` option. Second, we introduce a `prepare_import` step to the interface. Here, any customization can be done before the actual import starts.

Actual implementation of the datapackage handler will move to the contribs repository and can then be installed as mere dependency.